### PR TITLE
Add option 'veth-peer-name' to veth links and ensure proper configuration

### DIFF
--- a/ifupdownaddons/iproute2.py
+++ b/ifupdownaddons/iproute2.py
@@ -110,6 +110,8 @@ class iproute2(utilsBase):
                             linkattrs['kind'] = 'vlan'
                     elif citems[i] == 'dummy':
                         linkattrs['kind'] = 'dummy'
+                    elif citems[i] == 'veth':
+                        linkattrs['kind'] = 'veth'
                     elif citems[i] == 'vxlan' and citems[i + 1] == 'id':
                         linkattrs['kind'] = 'vxlan'
                         vattrs = {'vxlanid': citems[i + 2],


### PR DESCRIPTION
  The option »veth-peer-name« forces an veth peer link to be created with
  a specific interface name. As the interface name of the "local" part of
  the veth link pair already is defined by the name of the interface stanza
  this option is added to, now both sides are clearly named.

  As there is a bidirectional dependency of both link pairs - both cannot
  exist without the other - this presents a problem when setting up all
  interfaces. Depending on which interface is set up first there might be
  a problem when only on dependency is specified. Therefore adding the
  »veth-peer-name« option to both interface of the veth link pair ensures
  that regardless of which side is configured first the peer name will be
  set correctly. This intentionally creates a circular dependency which is
  handled accordingly.

  Fixing the config check for veth link-type while at it :)

Signed-off-by: Maximilian Wilhelm <max@rfc2324.org>