### PR TITLE
For hotplug devices check if the link is present, not up

### DIFF
--- a/sbin/start-networking
+++ b/sbin/start-networking
@@ -87,10 +87,9 @@ ifup_hotplug () {
 			    do
 				    link=${iface##:*}
 				    link=${link##.*}
-				    ip link set "$iface" up || true
-				    if [ "$(cat /sys/class/net/$link/operstate)" = up ]
+				    if [ -e "/sys/class/net/$link" ]
 				    then
-					    echo "$iface"
+				        echo "$iface"
 				    fi
 			    done)
 	    if [ -n "$ifaces" ]


### PR DESCRIPTION
Checking operstate would require firmware to be loaded and link
negotiation to of taken place. Some firmwares take a few seconds to
upload and online the device, and some link negotiations take a second
or two.

Immediately checking operstate is not feasible here. Checking if the
link is present is a more suitable non-delaying approach.

Signed-off-by: Nigel Kukard <nkukard@lbsd.net>