### PR TITLE
Pass environment variables to addon scripts

### DIFF
--- a/ifupdown/scheduler.py
+++ b/ifupdown/scheduler.py
@@ -109,6 +109,10 @@ class ifaceScheduler():
 
         if ifupdownobj.config.get('addon_scripts_support', '0') == '1':
             # execute /etc/network/ scripts 
+            os.environ['IFACE'] = ifaceobj.name if ifaceobj.name else ''
+            os.environ['LOGICAL'] = ifaceobj.name if ifaceobj.name else ''
+            os.environ['METHOD'] = ifaceobj.addr_method if ifaceobj.addr_method else ''
+            os.environ['ADDRFAM'] = ','.join(ifaceobj.addr_family) if ifaceobj.addr_family else ''
             for mname in ifupdownobj.script_ops.get(op, []):
                 ifupdownobj.logger.debug('%s: %s : running script %s'
                     %(ifacename, op, mname))


### PR DESCRIPTION
Pass the same environment variables to addon scripts from /etc/network/
as are passed to user defined commands in interfaces stanzas. This is
needed for compatibility with ifupdown.

Fixes: #14