### PR TITLE
addons: bridge: allow "bridge-ports: none" for bridges without initial ports.

### DIFF
--- a/addons/bridge.py
+++ b/addons/bridge.py
@@ -298,7 +298,13 @@ class bridge(moduleBase):
         if ports and len(ports) > 1:
             self.log_warn('%s: ignoring duplicate bridge-ports lines: %s'
                           %(ifaceobj.name, ports[1:]))
-        return ports[0] if ports else None
+        if ports:
+            if 'none' in ports[0]:
+                return []
+
+            return ports[0]
+
+        return None
 
     def _is_bridge_port(self, ifaceobj):
         if self.brctlcmd.is_bridge_port(ifaceobj.name):


### PR DESCRIPTION
  This simple patch allows the creation of bridges which should be set up
  without any ports, like a bridge for virtual machines on a hosting box.

  With this patch ifupdown2 get's a step closer to feature parity and
  compatiblity with ifupdown1.

Signed-off-by: Maximilian Wilhelm <max@sdn.clinic>