### PR TITLE
addons: tunnel: Add support for GRETAP tunnels.

### DIFF
--- a/addons/tunnel.py
+++ b/addons/tunnel.py
@@ -14,11 +14,11 @@ import logging
 # TODO: Add checks for ipip tunnels.
 #
 class tunnel (moduleBase):
-    _modinfo = { 'mhelp' : 'create/configure GRE/IPIP/SIT tunnel interfaces',
+    _modinfo = { 'mhelp' : 'create/configure GRE/IPIP/SIT and GRETAP tunnel interfaces',
                  'attrs' : {
                    'mode' :
                         { 'help' : 'type of tunnel as in \'ip link\' command.',
-                          'validvals' : ['gre', 'ipip', 'sit'],
+                          'validvals' : ['gre', 'gretap', 'ipip', 'sit'],
                           'required' : True,
                           'example' : ['mode gre']},
                    'local' :

--- a/ifupdownaddons/iproute2.py
+++ b/ifupdownaddons/iproute2.py
@@ -103,14 +103,14 @@ class iproute2(utilsBase):
                         linkattrs['state'] = citems[i + 1]
                     elif citems[i] == 'link/ether':
                         linkattrs['hwaddress'] = citems[i + 1]
-                    elif citems[i] in [ 'link/gre', 'link/sit' ]:
+                    elif citems[i] in [ 'link/gre', 'link/sit', 'gretap' ]:
                         linkattrs['kind'] = 'tunnel'
-                        tunattrs = {'mode' : citems[i].split ('/')[1],
+                        tunattrs = {'mode' : citems[i].split ('/')[-1],
                                     'endpoint' : None,
                                     'local' : None,
                                     'ttl' : None,
                                     'physdev' : None}
-                        for j in range(i + 2, len(citems)):
+                        for j in range(i, len(citems)):
                             if citems[j] == 'local':
                                 tunattrs['local'] = citems[j + 1]
                             elif citems[j] == 'remote':


### PR DESCRIPTION
  This commit adds support to configure and check gretap tunnels. An example
  configuration could look like this:

    iface tap0 inet tunnel
        mode gretap
        local 10.132.255.3
        endpoint 10.132.255.1
        ttl 64
        mtu 1400
        tunnel-physdev eth0
        #
        address 10.10.0.1/2

  ifup will happily configure the interface (which it does even without this
  patch) and ifquery now can successfully validate the configure interface:

    cr03.in.ffho.net:~# ifquery -c tap0
    iface tap0 inet tunnel                   [[ OK ]]
        tunnel-physdev eth0                  [[ OK ]]
        endpoint 10.132.255.1                [[ OK ]]
        local 10.132.255.3                   [[ OK ]]
        mode gretap                          [[ OK ]]
        ttl 64                               [[ OK ]]
        mtu 1400                             [[ OK ]]
        address 10.10.0.1/24                 [[ OK ]]

Signed-off-by: Maximilian Wilhelm <max@sdn.clinic>