### PR TITLE
addons: batman_adv: Add support for more B.A.T.M.A.N. adv. attributes.

### DIFF
--- a/addons/batman_adv.py
+++ b/addons/batman_adv.py
@@ -36,9 +36,31 @@ class batman_adv (moduleBase):
                 'required' : False,
             },
 
+            'batman-distributed-arp-table' : {
+                'help' : 'B.A.T.M.A.N. distributed ARP table',
+                'validvals' : [ 'enabled', 'disabled' ],
+                'required' : False,
+                'batman-attr' : True,
+            },
+
+            'batman-gw-mode' : {
+                'help' : 'B.A.T.M.A.N. gateway mode',
+                'validvals' : [ 'off', 'client', 'server' ],
+                'required' : False,
+                'example' : [ 'batman-gw-mode client' ],
+                'batman-attr' : True,
+            },
+
             'batman-hop-penalty' : {
                 'help' : 'B.A.T.M.A.N. hop penalty',
                 'validvals' : [ '<number>' ],
+                'required' : False,
+                'batman-attr' : True,
+            },
+
+            'batman-multicast-mode' : {
+                'help' : 'B.A.T.M.A.N. multicast mode',
+                'validvals' : [ 'enabled', 'disabled' ],
                 'required' : False,
                 'batman-attr' : True,
             },


### PR DESCRIPTION
This series reworks the internal handling of B.A.T.M.A.N. adv. attributes within the addon and adds support for the following new attributes:

  * gw-mode (one of { off, client, server })
  * multicast-mode (can be 'enabled' or 'disabled')
  * distributed-arp-table (cat be 'enabled' or 'disabled')

Example config:

```
pandora:~# ifquery -c bat-foo
iface bat-foo                                         [pass]
    batman-ifaces dummy-bat                           [pass]
    batman-ifaces-ignore-regex                        [pass]
    batman-hop-penalty 7                              [pass]
    batman-multicast-mode enabled                     [pass]
    batman-distributed-arp-table enabled              [pass]
    batman-gw-mode client                             [pass]
```

Signed-off-by: Maximilian Wilhelm <max@sdn.clinic>