### PR TITLE
netlink fix

### DIFF
--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -542,6 +542,10 @@ class AttributeMACAddress(Attribute):
                 self.value = IPv4Address(unpack('>L', self.data[4:])[0])
                 self.value_int = int(self.value)
                 self.value_int_str = str(self.value_int)
+            elif self.length == 20:
+                self.value = IPv6Address(unpack('>L', self.data[16:])[0])
+                self.value_int = int(self.value)
+                self.value_int_str = str(self.value_int)
             else:
                 raise Exception("Length of MACAddress attribute not supported: %d" % self.length)
 


### PR DESCRIPTION
Hi,

there is an error in the netlink library at AttributeMACAddress.
IPv6 is not processed and raises an exception which basically renders the netlink unusable since all netlink calls end up with an exception and no data.

Best
Sven