### PR TITLE
netlink: nlpacket AttributeMACAddress

### DIFF
--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -533,14 +533,17 @@ class AttributeMACAddress(Attribute):
 
     def decode(self, parent_msg, data):
         self.decode_length_type(data)
-
+        
+        # IFLA_ADDRESS and IFLA_BROADCAST attributes for all interfaces has been a
+        # 6-byte MAC address. But the GRE interface uses a 4-byte IP address and 
+        # GREv6 uses a 16-byte IPv6 address for this attribute.
         try:
-            # MAC Address 
+            # GRE interface uses a 4-byte IP address for this attribute
             if self.length == 8:
                 self.value = IPv4Address(unpack('>L', self.data[4:])[0])
                 self.value_int = int(self.value)
                 self.value_int_str = str(self.value_int)
-            # GRE interface uses a 4-byte IP address for this attribute
+            # MAC Address 
             elif self.length == 10:
                 (data1, data2) = unpack(self.PACK, self.data[4:])
                 self.value = mac_int_to_str(data1 << 16 | data2)

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -535,11 +535,18 @@ class AttributeMACAddress(Attribute):
         self.decode_length_type(data)
 
         try:
-            if self.length == 10:
+            # MAC Address 
+            if self.length == 8:
+                self.value = IPv4Address(unpack('>L', self.data[4:])[0])
+                self.value_int = int(self.value)
+                self.value_int_str = str(self.value_int)
+            # GRE interface uses a 4-byte IP address for this attribute
+            elif self.length == 10:
                 (data1, data2) = unpack(self.PACK, self.data[4:])
                 self.value = mac_int_to_str(data1 << 16 | data2)
-            elif self.length == 8:
-                self.value = IPv4Address(unpack('>L', self.data[4:])[0])
+            # GREv6 interface uses a 16-byte IP address for this attribute 
+            elif self.length == 20:
+                self.value = IPv6Address(unpack('>L', self.data[16:])[0])
                 self.value_int = int(self.value)
                 self.value_int_str = str(self.value_int)
             else:


### PR DESCRIPTION
This commits fixes AttributeMACAddress for GREv6.
Error message: info: netlink: link dump failed: Length of MACAddress attribute not supported: 20
Reproducible by adding a GREv6 Tunnel:

auto gre1
iface gre1 inet tunnel
    mode ip6gre
    local 2001:1000:1000:1000::123
    endpoint 2001:1000:1000:2000::123
    address 192.168.123.1/29

In netlink The IFLA_ADDRESS and IFLA_BROADCAST attributes for all interfaces has been a
6-byte MAC address. But the GRE interface uses a 4-byte IP address and GREv6 uses a 16-byte IPv6 address for this
attribute. This patch allows for decoding a 16-byte value as an IP address.