### PR TITLE
Tunnel fixes master

### DIFF
--- a/ifupdownaddons/iproute2.py
+++ b/ifupdownaddons/iproute2.py
@@ -119,6 +119,8 @@ class iproute2(utilsBase):
                                 tunattrs['ttl'] = citems[j + 1]
                             elif citems[j] == 'dev':
                                 tunattrs['physdev'] = citems[j + 1]
+                            elif citems[j] in ['vti', 'vti6', 'ip6gre', 'ipip6', 'ip6ip6']:
+                                tunattrs['mode'] = citems[j]
                         linkattrs['linkinfo'] = tunattrs
                         break
                     elif citems[i] == 'link/ppp':

--- a/ifupdownaddons/iproute2.py
+++ b/ifupdownaddons/iproute2.py
@@ -763,39 +763,26 @@ class iproute2(utilsBase):
         """ generic link_create function """
         if self.link_exists(tunnelname):
             return
-        
+
         cmd = ''
         if '6' in mode:
             cmd = ' -6 '
 
-        cmd += 'tunnel add'
-        cmd += ' %s mode %s' %(tunnelname, mode)
+        if mode in ['gretap']:
+            cmd += 'link add %s type %s' % (tunnelname, mode)
+        else:
+            cmd += 'tunnel add %s mode %s' % (tunnelname, mode)
+
         if attrs:
             for k, v in attrs.iteritems():
-                cmd += ' %s' %k
+                cmd += ' %s' % k
                 if v:
-                    cmd += ' %s' %v
+                    cmd += ' %s' % v
         if self.ipbatch and not self.ipbatch_pause:
             self.add_to_batch(cmd)
         else:
             utils.exec_command('ip %s' % cmd)
         self._cache_update([tunnelname], {})
-
-    def tunnel_change(self, tunnelname, attrs={}):
-        """ tunnel change function """
-        if not self.link_exists(tunnelname):
-            return
-        cmd = 'tunnel change'
-        cmd += ' %s' %(tunnelname)
-        if attrs:
-            for k, v in attrs.iteritems():
-                cmd += ' %s' %k
-                if v:
-                    cmd += ' %s' %v
-        if self.ipbatch and not self.ipbatch_pause:
-            self.add_to_batch(cmd)
-        else:
-            utils.exec_command('ip %s' % cmd)
 
     def bridge_port_vids_add(self, bridgeportname, vids):
         [utils.exec_command('bridge vlan add vid %s dev %s' %


### PR DESCRIPTION
Create all tunnels - except gretap - with 'ip tunnel', as this supports
  most tunnel modes; create gretap tunnels with 'ip link'.

  Rework the whole concept of tunnel updates and make sure a tunnel only is
  changed - recreated - IFF the configuration has changed. In previos code
  'tunnel change' was called on every _up() call. The 'tunnel change' part
  was removed completely as it doesn't work on many occations. So IFF the
  tunnel related interface configuration has changed, the tunnel is removed
  and recreated.

  Latest additions added a bunch of new tunnel modes but didn't add support
  to read in these modes which breaks 'ifquery' as it falsely marks the mode
  as 'fail'.

This addresses Issue #78 