### PR TITLE
Add python-setuptools as required preinstalled package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ You might need to manually download dependencies. Mandatory dependencies:
 
 .. code-block:: console
 
-    $ apt-get install build-essential devscripts dh-systemd fakeroot python-all python-docutils iproute2 python-ipaddr python-argcomplete
+    $ apt-get install build-essential devscripts dh-systemd fakeroot python-all python-docutils iproute2 python-ipaddr python-argcomplete python-setuptools
 
 Suggested dependencies:
 


### PR DESCRIPTION
On some kind-of-minimalistic  Ubuntu 18.04.1 extra python package `python-setuptools` was needed in order to compile from source the final DEB.

```
dpkg-buildpackage: info: source version 1.2.1
dpkg-buildpackage: info: source changed by Julien Fortin <julien@cumulusnetworks.com>
 dpkg-source --before-build ifupdown2
dpkg-buildpackage: info: host architecture amd64
dpkg-checkbuilddeps: error: Unmet build dependencies: python-setuptools
dpkg-buildpackage: warning: build dependencies/conflicts unsatisfied; aborting
```