### PR TITLE
Do not purge the cache on tunnel change. It will still be valid and w…

### DIFF
--- a/ifupdown2/ifupdownaddons/LinkUtils.py
+++ b/ifupdown2/ifupdownaddons/LinkUtils.py
@@ -1303,7 +1303,6 @@ class LinkUtils(utilsBase):
             self.add_to_batch(cmd)
         else:
             utils.exec_command('ip %s' % cmd)
-        self._cache_update([tunnelname], {})
 
     def link_create_vxlan(self, name, vxlanid,
                           localtunnelip=None,


### PR DESCRIPTION
…e need the attributes to make changes to the ipaddresses.

@julienfortin this is a small fix so we do not purge the cache on tunnel change. Tunnel changes are always minor, we recreate them if they are big.

Without this fix the address management does not work.