### PR TITLE
debian: Add RequiresMountsFor=/var/tmp to networking.service

### DIFF
--- a/debian/ifupdown2.networking.service
+++ b/debian/ifupdown2.networking.service
@@ -4,6 +4,7 @@ Documentation=man:interfaces(5) man:ifup(8) man:ifdown(8)
 DefaultDependencies=no
 Before=shutdown.target
 Conflicts=shutdown.target
+RequiresMountsFor=/var/tmp
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
  On Debian Testing interfaces aren't configured on boot when /var/tmp/network
  is not available as it might be on a seperate file system. Add a dependency
  to ensure correct order and behavior.

Signed-off-by: Maximilian Wilhelm <max@sdn.clinic>