### PR TITLE
explicitly enable ipv6 when it's being used

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -410,21 +410,22 @@ class address(moduleBase):
             anycast_addr = utils.get_normalized_ip_addr(ifaceobj.name, self._get_anycast_addr(ifaceobjlist))
 
             if runningaddrs and anycast_addr and anycast_addr in runningaddrs:
-                newaddrs.append(anycast_addr)
+                anycast_obj = utils.get_ip_objs(module_name, ifname, [anycast_addr])
+                newaddrs.append(anycast_obj[0])
 
-            user_ip4, user_ip6, newaddrs = self.order_user_configured_addrs(newaddrs)
+            user_ip4, user_ip6, addrstrs = self.order_user_configured_addrs(newaddrs)
 
-            if newaddrs == runningaddrs or self.compare_running_ips_and_user_config(user_ip4, user_ip6, runningaddrs):
+            if addrstrs == runningaddrs or self.compare_running_ips_and_user_config(user_ip4, user_ip6, runningaddrs):
                 if force_reapply:
                     self._inet_address_list_config(ifaceobj, newaddrs, newaddr_attrs)
                 return
             try:
                 # if primary address is not same, there is no need to keep any.
                 # reset all addresses
-                if newaddrs and runningaddrs and newaddrs[0] != runningaddrs[0]:
+                if addrstrs and runningaddrs and addrstrs[0] != runningaddrs[0]:
                     skip_addrs = []
                 else:
-                    skip_addrs = newaddrs or []
+                    skip_addrs = addrstrs or []
                 for addr in runningaddrs or []:
                     if addr in skip_addrs:
                         continue


### PR DESCRIPTION
Recreated against current master as the PR previously seems to have been auto-closed by a force-push which also made it hard to access via github.

--

On a hypervisor host one setting that is very useful is `net.ipv6.conf.default.disable_ipv6=1`. This avoids ipv6 link local addresses on veths and tap devices of VMs being brought up (including accidental autoconfiguration, listening to route-adverising on these interfaces etc.). However, doing this also causes bridges to start off with the same setting, which means `ifup` will fail on bridges with ipv6 addresses.
A `pre-up` script will run before the bridge is created, while an `up` script will run after address configuration, so neither is a good option in this case.

Given that with autoconf/RA/etc. explicitly whitelisting ipv6 interfaces makes more sense I wonder if this should be handled either directly, or via an option.
Personally I'd say if an IPv6 is configured it should also be enabled. We can already choose whether we want link-local addressing in a nother option: `ipv6-addrgen`.