### PR TITLE
Update vrf.py

### DIFF
--- a/ifupdown2/addons/vrf.py
+++ b/ifupdown2/addons/vrf.py
@@ -509,32 +509,32 @@ class vrf(moduleBase):
         ip_rule_out_format = '%s: from all %s %s lookup %s'
         ip_rule_cmd = '%s %s rule del pref %s %s %s table %s'
 
-        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_table)
         if rule in self.ip_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '', pref, 'oif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_table)
         if rule in self.ip_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '', pref, 'iif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_table)
         if rule in self.ip6_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '-6', pref, 'oif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_table)
         if rule in self.ip6_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '-6', pref, 'iif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
     def _l3mdev_rule(self, ip_rules):

--- a/ifupdown2/addons/vrf.py
+++ b/ifupdown2/addons/vrf.py
@@ -588,32 +588,32 @@ class vrf(moduleBase):
         #200: from all oif blue lookup blue
         #200: from all iif blue lookup blue
 
-        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_table)
         if not self.l3mdev4_rule and rule not in self.ip_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '', pref, 'oif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_table)
         if not self.l3mdev4_rule and rule not in self.ip_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '', pref, 'iif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'oif', vrf_dev_name, vrf_table)
         if not self.l3mdev6_rule and rule not in self.ip6_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '-6', pref, 'oif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
-        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_dev_name)
+        rule = ip_rule_out_format %(pref, 'iif', vrf_dev_name, vrf_table)
         if not self.l3mdev6_rule and rule not in self.ip6_rule_cache:
             rule_cmd = ip_rule_cmd %(utils.ip_cmd,
                                      '-6', pref, 'iif', vrf_dev_name,
-                                     vrf_dev_name)
+                                     vrf_table)
             utils.exec_command(rule_cmd)
 
     def _is_address_virtual_slaves(self, vrfobj, config_vrfslaves,


### PR DESCRIPTION
Fixed variables for ip rule commands.

Was incorrectly referencing vrf_dev_name, instead of vrf_table.
Caused ip rule cmd to fail.


Before:
ip rule add pref 200 oif {{vrf_dev_name}} table {{vrf_dev_name}}

After:
ip rule add pref 200 oif {{vrf_dev_name}} table {{vrf_table}}