### PR TITLE
allow vlan subinterface in a vlan-aware bridge

### DIFF
--- a/ifupdown2/addons/bridge.py
+++ b/ifupdown2/addons/bridge.py
@@ -773,11 +773,6 @@ class bridge(moduleBase):
             result = True
             for port_name in ports:
                 port_obj_l = ifaceobj_getfunc(port_name)
-                if port_obj_l and port_obj_l[0].link_kind & ifaceLinkKind.VLAN:
-                    self.logger.error('%s: %s: vlan sub-interface is not '
-                                      'supported in a vlan-aware bridge'
-                                      % (ifaceobj.name, port_name))
-                    result = False
                 if (port_obj_l and
                     port_obj_l[0].get_attr_value('bridge-arp-nd-suppress') and
                     self.arp_nd_suppress_only_on_vxlan and


### PR DESCRIPTION
for stacked/qinq vlan, it's perfectly fine to have a vlan-aware bridge with a tagged interface port

fix:
https://github.com/CumulusNetworks/ifupdown2/issues/92

sample config:

auto eth0.2
iface eth0.2 inet manual

auto bridge
iface bridge inet manual
        bridge-ports eth0.2
        bridge-stp off
        bridge-fd 0
        bridge-vlan-aware yes

# brctl show:

bridge		8000.c81f66f8688c	no		eth0.2

Signed-off-by: Alexandre Derumier <aderumier@odiso.com>