### PR TITLE
don't change interface forwarding value if not defined

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -716,6 +716,11 @@ class address(moduleBase):
                                'bridge port' %ifaceobj.name)
             return
 
+        setting_default_value = False
+        if not ipforward:
+            setting_default_value = True
+            ipforward = self.ipforward
+
         if ipforward:
             ipforward = utils.boolean_support_binary(ipforward)
             # File read has been used for better performance
@@ -731,8 +736,15 @@ class address(moduleBase):
                                     %('/'.join(ifaceobj.name.split("."))),
                                     ipforward)
                 except Exception as e:
-                    ifaceobj.status = ifaceStatus.ERROR
-                    self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
+                    if not setting_default_value:
+                        ifaceobj.status = ifaceStatus.ERROR
+                        self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
+
+
+        setting_default_value = False
+        if not ip6forward:
+            setting_default_value = True
+            ip6forward = self.ip6forward
 
         if ip6forward:
             ip6forward = utils.boolean_support_binary(ip6forward)
@@ -751,8 +763,9 @@ class address(moduleBase):
                     # for example, setting mtu < 1280
                     # In such cases, log error only if user has configured
                     # ip6-forward
-                    ifaceobj.status = ifaceStatus.ERROR
-                    self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
+                    if not setting_default_value:
+                        ifaceobj.status = ifaceStatus.ERROR
+                        self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
 
     def process_mtu(self, ifaceobj, ifaceobj_getfunc):
         mtu = ifaceobj.get_attr_value_first('mtu')

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -715,49 +715,42 @@ class address(moduleBase):
                 self.log_error('%s: \'ip6-forward\' is not supported for '
                                'bridge port' %ifaceobj.name)
             return
-        setting_default_value = False
-        if not ipforward:
-            setting_default_value = True
-            ipforward = (self.ipforward or
-                         self.get_mod_subattr('ip-forward', 'default'))
-        ipforward = utils.boolean_support_binary(ipforward)
-        # File read has been used for better performance
-        # instead of using sysctl command
-        running_ipforward = self.read_file_oneline(
-                                '/proc/sys/net/ipv4/conf/%s/forwarding'
-                                %ifaceobj.name)
-        if ipforward != running_ipforward:
-            try:
-                self.sysctl_set('net.ipv4.conf.%s.forwarding'
-                                %('/'.join(ifaceobj.name.split("."))),
-                                ipforward)
-            except Exception as e:
-                if not setting_default_value:
+
+        if ipforward:
+            ipforward = utils.boolean_support_binary(ipforward)
+            # File read has been used for better performance
+            # instead of using sysctl command
+            running_ipforward = self.read_file_oneline(
+                                    '/proc/sys/net/ipv4/conf/%s/forwarding'
+                                   %ifaceobj.name)
+
+            if ipforward != running_ipforward:
+                try:
+
+                    self.sysctl_set('net.ipv4.conf.%s.forwarding'
+                                    %('/'.join(ifaceobj.name.split("."))),
+                                    ipforward)
+                except Exception as e:
                     ifaceobj.status = ifaceStatus.ERROR
                     self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
 
-        setting_default_value = False
-        if not ip6forward:
-            setting_default_value = True
-            ip6forward = (self.ip6forward or
-                          self.get_mod_subattr('ip6-forward', 'default'))
-        ip6forward = utils.boolean_support_binary(ip6forward)
-        # File read has been used for better performance
-        # instead of using sysctl command
-        running_ip6forward = self.read_file_oneline(
-                                '/proc/sys/net/ipv6/conf/%s/forwarding'
-                                %ifaceobj.name)
-        if ip6forward != running_ip6forward:
-            try:
-                self.sysctl_set('net.ipv6.conf.%s.forwarding'
-                                %('/'.join(ifaceobj.name.split("."))),
-                                ip6forward)
-            except Exception as e:
-                # There is chance of ipv6 being removed because of,
-                # for example, setting mtu < 1280
-                # In such cases, log error only if user has configured
-                # ip6-forward
-                if not setting_default_value:
+        if ip6forward:
+            ip6forward = utils.boolean_support_binary(ip6forward)
+            # File read has been used for better performance
+            # instead of using sysctl command
+            running_ip6forward = self.read_file_oneline(
+                                    '/proc/sys/net/ipv6/conf/%s/forwarding'
+                                    %ifaceobj.name)
+            if ip6forward != running_ip6forward:
+                try:
+                    self.sysctl_set('net.ipv6.conf.%s.forwarding'
+                                    %('/'.join(ifaceobj.name.split("."))),
+                                    ip6forward)
+                except Exception as e:
+                    # There is chance of ipv6 being removed because of,
+                    # for example, setting mtu < 1280
+                    # In such cases, log error only if user has configured
+                    # ip6-forward
                     ifaceobj.status = ifaceStatus.ERROR
                     self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
 


### PR DESCRIPTION
classic ifupdown don't change forwarding value if not defined in /etc/network/interfaces (don't even support it).

Currently ifupdown2 behaviour is to turn forwarding off when not defined. (and break sysctl manual enabling (net.ipv4.ip_forward = 1, net.ipv4.conf.all.forwarding = 1, net.ipv4.conf.default.forwarding = 1
 on restart or reload).

Better to not change value when not defined, and keep user manual config.
