### PR TITLE
ifupdown2addons: fix order of pre-up,vrf and pre-up,tunnel

### DIFF
--- a/etc/network/ifupdown2/addons.conf
+++ b/etc/network/ifupdown2/addons.conf
@@ -9,8 +9,8 @@ pre-up,usercmds
 pre-up,bridge
 pre-up,bridgevlan
 pre-up,mstpctl
-pre-up,vrf
 pre-up,tunnel
+pre-up,vrf
 pre-up,ethtool
 up,dhcp
 up,address


### PR DESCRIPTION
Fixes the vrf addon trying to set the master on a tunnel interface, before it has been created.

Example:
```ifupdown2
iface vrf-test inet manual
    vrf-table 1001
iface test-tunnel inet tunnel
    # tunnel config here
    vrf vrf-test
```