### PR TITLE
Fix error message on ifquery when sysctl bridge-stp-user-space

### DIFF
--- a/ifupdown2/ifupdownaddons/modulebase.py
+++ b/ifupdown2/ifupdownaddons/modulebase.py
@@ -322,7 +322,11 @@ class moduleBase(object):
     def systcl_get_net_bridge_stp_user_space(self):
         if self._bridge_stp_user_space:
             return self._bridge_stp_user_space
-        self._bridge_stp_user_space = self.sysctl_get('net.bridge.bridge-stp-user-space')
+        try:
+            self._bridge_stp_user_space = self.sysctl_get('net.bridge.bridge-stp-user-space')
+        except:
+            self._bridge_stp_user_space = 0
+
         return self._bridge_stp_user_space
 
     def set_iface_attr(self, ifaceobj, attr_name, attr_valsetfunc,


### PR DESCRIPTION
This fix this kind of error:

 ifquery -r -a

error: bond0: cmd '/sbin/sysctl net.bridge.bridge-stp-user-space' failed: returned 255 (sysctl: cannot stat /proc/sys/net/bridge/bridge-stp-user-space: No such file or directory
)
error: fwpr103p0: cmd '/sbin/sysctl net.bridge.bridge-stp-user-space' failed: returned 255 (sysctl: cannot stat /proc/sys/net/bridge/bridge-stp-user-space: No such file or directory
)