### PR TITLE
This commit adds support for the new IPSec Interface XFRM.

### DIFF
--- a/etc/network/ifupdown2/addons.conf
+++ b/etc/network/ifupdown2/addons.conf
@@ -1,3 +1,4 @@
+pre-up,xfrm
 pre-up,link
 pre-up,ppp
 pre-up,bond
@@ -39,3 +40,4 @@ post-down,batman_adv
 post-down,usercmds
 post-down,link
 post-down,tunnel
+post-down,xfrm

--- a/ifupdown2/addons/xfrm.py
+++ b/ifupdown2/addons/xfrm.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #
-# Copyright 2014-2017 Cumulus Networks, Inc. All rights reserved.
-# Author: Roopa Prabhu, roopa@cumulusnetworks.com
+# Copyright 2019 Voleatech GmbH. All rights reserved.
+# Author: Sven Auhagen, sven.auhagen@voleatech.de
 #
 
 import os

--- a/ifupdown2/addons/xfrm.py
+++ b/ifupdown2/addons/xfrm.py
@@ -40,10 +40,10 @@ class xfrm(moduleBase):
     """  ifupdown2 addon module to create a xfrm interface """
     _modinfo = {'mhelp' : 'xfrm module creates a xfrm interface for',
                 'attrs' : {
-                    'xfrmid' :
+                    'xfrm-id' :
                         { 'help' : 'xfrm id',
                           'validrange' : ['1', '65535'],
-                          'example': ['xfrmid 1'] 
+                          'example': ['xfrm-id 1'] 
                         },
                     'xfrm-physdev':
                         {'help': 'xfrm physical device',
@@ -73,8 +73,8 @@ class xfrm(moduleBase):
         return None
 
     def _get_xfrmid(self, ifaceobj):
-        if ifaceobj.get_attr_value('xfrmid'):
-            av_attr = ifaceobj.get_attr_value_first('xfrmid')
+        if ifaceobj.get_attr_value('xfrm-id'):
+            av_attr = ifaceobj.get_attr_value_first('xfrm-id')
             return av_attr
 
         return None
@@ -84,7 +84,7 @@ class xfrm(moduleBase):
 
     @staticmethod
     def _is_my_interface(ifaceobj):
-        return ifaceobj.get_attr_value_first('xfrmid')
+        return ifaceobj.get_attr_value_first('xfrm-id')
 
     def _up(self, ifaceobj):
         """
@@ -104,7 +104,7 @@ class xfrm(moduleBase):
             link_created = True
         else:
             current_attrs = self.ipcmd.link_get_linkinfo_attrs(ifaceobj.name)
-            xfrmid_cur = current_attrs.get('xfrmid', None)
+            xfrmid_cur = current_attrs.get('xfrm-id', None)
             physdev_cur = current_attrs.get('xfrm-physdev', None)
             # Check XFRM Values
             if xfrmid != xfrmid_cur or physdev != physdev_cur:

--- a/ifupdown2/addons/xfrm.py
+++ b/ifupdown2/addons/xfrm.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+#
+# Copyright 2014-2017 Cumulus Networks, Inc. All rights reserved.
+# Author: Roopa Prabhu, roopa@cumulusnetworks.com
+#
+
+import os
+import glob
+import socket
+
+from ipaddr import IPNetwork, IPv6Network
+
+try:
+    from ifupdown2.ifupdown.iface import *
+    from ifupdown2.ifupdown.utils import utils
+    from ifupdown2.ifupdown.netlink import netlink
+
+    from ifupdown2.ifupdownaddons.LinkUtils import LinkUtils
+    from ifupdown2.ifupdownaddons.modulebase import moduleBase
+
+    import ifupdown2.ifupdown.statemanager as statemanager
+    import ifupdown2.ifupdown.policymanager as policymanager
+    import ifupdown2.ifupdown.ifupdownflags as ifupdownflags
+    import ifupdown2.ifupdown.ifupdownconfig as ifupdownconfig
+except ImportError:
+    from ifupdown.iface import *
+    from ifupdown.utils import utils
+    from ifupdown.netlink import netlink
+
+    from ifupdownaddons.LinkUtils import LinkUtils
+    from ifupdownaddons.modulebase import moduleBase
+
+    import ifupdown.statemanager as statemanager
+    import ifupdown.policymanager as policymanager
+    import ifupdown.ifupdownflags as ifupdownflags
+    import ifupdown.ifupdownconfig as ifupdownconfig
+
+
+class xfrm(moduleBase):
+    """  ifupdown2 addon module to create a xfrm interface """
+    _modinfo = {'mhelp' : 'xfrm module creates a xfrm interface for',
+                'attrs' : {
+                    'xfrmid' :
+                        { 'help' : 'xfrm id',
+                          'validrange' : ['1', '65535'],
+                          'example': ['xfrmid 1'] 
+                        },
+                    'xfrm-physdev':
+                        {'help': 'xfrm physical device',
+                         'example': ['xfrm-physdev lo']
+                        },
+                    },
+                }
+
+
+    def __init__(self, *args, **kargs):
+        moduleBase.__init__(self, *args, **kargs)
+        self.ipcmd = None
+
+    def get_dependent_ifacenames(self, ifaceobj, ifacenames_all=None):
+
+        parent_int = self._get_parent_ifacename(ifaceobj)
+        if parent_int:
+            return [parent_int]
+
+        return None
+
+    def _get_parent_ifacename(self, ifaceobj):
+        if ifaceobj.get_attr_value('xfrm-physdev'):
+            av_attr = ifaceobj.get_attr_value_first('xfrm-physdev')
+            return av_attr
+
+        return None
+
+    def _get_xfrmid(self, ifaceobj):
+        if ifaceobj.get_attr_value('xfrmid'):
+            av_attr = ifaceobj.get_attr_value_first('xfrmid')
+            return av_attr
+
+        return None
+
+    def _get_xfrm_name(self, ifaceobj):
+        return ifaceobj.name
+
+    @staticmethod
+    def _is_my_interface(ifaceobj):
+        return ifaceobj.get_attr_value_first('xfrmid')
+
+    def _up(self, ifaceobj):
+        """
+        Up the XFRM Interface
+        """
+        # Create a xfrm device on this device and set the virtual
+        # router mac and ip on it
+        link_created = False
+        xfrm_ifacename = self._get_xfrm_name(ifaceobj)
+        physdev = self._get_parent_ifacename(ifaceobj)
+        xfrmid = self._get_xfrmid(ifaceobj)
+        if not self.ipcmd.link_exists(xfrm_ifacename):
+            try:
+                netlink.link_add_xfrm(physdev, xfrm_ifacename, xfrmid)
+            except:
+                self.ipcmd.link_add_xfrm(physdev, xfrm_ifacename, xfrmid)
+            link_created = True
+        else:
+            current_attrs = self.ipcmd.link_get_linkinfo_attrs(ifaceobj.name)
+            xfrmid_cur = current_attrs.get('xfrmid', None)
+            physdev_cur = current_attrs.get('xfrm-physdev', None)
+            # Check XFRM Values
+            if xfrmid != xfrmid_cur or physdev != physdev_cur:
+                # Delete and recreate
+                self.ipcmd.link_delete(xfrm_ifacename)
+                try:
+                    netlink.link_add_xfrm(physdev, xfrm_ifacename, xfrmid)
+                except:
+                    self.ipcmd.link_add_xfrm(physdev, xfrm_ifacename, xfrmid)
+                link_created = True
+
+    def _down(self, ifaceobj, ifaceobj_getfunc=None):
+        """
+        Down the XFRM Interface
+        """
+        try:
+            xfrm_ifacename = self._get_xfrm_name(ifaceobj)
+            self.ipcmd.link_delete(xfrm_ifacename)
+        except Exception, e:
+            self.log_warn(str(e))
+
+    def _query_check(self, ifaceobj, ifaceobjcurr):
+        if not self.ipcmd.link_exists(ifaceobj.name):
+            return
+        ifaceobjcurr.status = ifaceStatus.SUCCESS
+
+    def _query_running(self, ifaceobjrunning):
+        if not self.ipcmd.link_exists(ifaceobjrunning.name):
+            return
+
+    # Operations supported by this addon (yet).
+    _run_ops = {
+        'pre-up': _up,
+        'post-down': _down,
+        'query-checkcurr': _query_check,
+        'query-running': _query_running,
+    }
+
+    def get_ops(self):
+        return self._run_ops.keys()
+
+    def _init_command_handlers(self):
+        if not self.ipcmd:
+            self.ipcmd = LinkUtils()
+
+    def run(self, ifaceobj, operation, query_ifaceobj=None, **extra_args):
+        op_handler = self._run_ops.get(operation)
+
+        if not op_handler:
+            return
+
+        if operation != 'query-running' and not self._is_my_interface(ifaceobj):
+            return
+
+        self._init_command_handlers()
+        if operation == 'query-checkcurr':
+            op_handler(self, ifaceobj, query_ifaceobj)
+        else:
+            op_handler(self, ifaceobj)

--- a/ifupdown2/ifupdown/netlink.py
+++ b/ifupdown2/ifupdown/netlink.py
@@ -560,7 +560,7 @@ class Netlink(utilsBase):
         xfrm_physdev_link_ifindex = linkdata.get(Link.IFLA_XFRM_LINK)
 
         return {
-            'xfrmid': str(linkdata.get(Link.IFLA_XFRM_IF_ID, '')),
+            'xfrm-id': str(linkdata.get(Link.IFLA_XFRM_IF_ID, '')),
             'xfrm-physdev': self.get_iface_name(xfrm_physdev_link_ifindex) if xfrm_physdev_link_ifindex else ""
         }
 

--- a/ifupdown2/ifupdown/netlink.py
+++ b/ifupdown2/ifupdown/netlink.py
@@ -64,7 +64,8 @@ class Netlink(utilsBase):
                 'sit': self._link_dump_info_data_iptun_tunnel,
                 'ip6tnl': self._link_dump_info_data_iptun_tunnel,
                 'vti': self._link_dump_info_data_vti_tunnel,
-                'vti6': self._link_dump_info_data_vti_tunnel
+                'vti6': self._link_dump_info_data_vti_tunnel,
+                'xfrm': self._link_dump_info_data_xfrm
             }
 
         except Exception as e:
@@ -221,6 +222,17 @@ class Netlink(utilsBase):
         except Exception as e:
             raise Exception('netlink: %s: cannot create macvlan %s: %s'
                             % (ifacename, macvlan_ifacename, str(e)))
+    
+    def link_add_xfrm(self, ifacename, xfrm_ifacename, xfrm_id):
+        self.logger.info('%s: netlink: ip link add %s type xfrm dev %s if_id %s'
+                         % (xfrm_ifacename, xfrm_ifacename, ifacename, xfrm_id))
+        if ifupdownflags.flags.DRYRUN: return
+        ifindex = self.get_iface_index(ifacename)
+        try:
+            return self._nlmanager_api.link_add_xfrm(ifindex, xfrm_ifacename, xfrm_id)
+        except Exception as e:
+            raise Exception('netlink: %s: cannot create xfrm %s id %s: %s'
+                            % (ifacename, xfrm_ifacename, xfrm_id, str(e)))
 
     def link_set_updown(self, ifacename, state):
         self.logger.info('%s: netlink: ip link set dev %s %s'
@@ -542,6 +554,14 @@ class Netlink(utilsBase):
             "endpoint": str(info_slave_data.get(Link.IFLA_VTI_REMOTE)),
             "local": str(info_slave_data.get(Link.IFLA_VTI_LOCAL)),
             "tunnel-physdev": self.get_iface_name(tunnel_link_ifindex) if tunnel_link_ifindex else ""
+        }
+
+    def _link_dump_info_data_xfrm(self, ifname, linkdata):
+        xfrm_physdev_link_ifindex = linkdata.get(Link.IFLA_XFRM_LINK)
+
+        return {
+            'xfrmid': str(linkdata.get(Link.IFLA_XFRM_IF_ID, '')),
+            'xfrm-physdev': self.get_iface_name(xfrm_physdev_link_ifindex) if xfrm_physdev_link_ifindex else ""
         }
 
     def _link_dump_linkinfo(self, link, dump):

--- a/ifupdown2/ifupdownaddons/LinkUtils.py
+++ b/ifupdown2/ifupdownaddons/LinkUtils.py
@@ -586,6 +586,8 @@ class LinkUtils(utilsBase):
                         break
                     elif citems[i] == 'macvlan' and citems[i + 1] == 'mode':
                         linkattrs['kind'] = 'macvlan'
+                    elif citems[i] == 'xfrm':
+                        linkattrs['kind'] = 'xfrm'
                 except Exception as e:
                     if warn:
                         self.logger.debug('%s: parsing error: id, mtu, state, '
@@ -1376,6 +1378,10 @@ class LinkUtils(utilsBase):
     @staticmethod
     def link_add_macvlan(ifname, macvlan_ifacename, mode):
         utils.exec_commandl(['ip', 'link', 'add',  'link', ifname, 'name', macvlan_ifacename, 'type', 'macvlan', 'mode', mode])
+
+    @staticmethod
+    def link_add_xfrm(ifname, xfrm_name, xfrm_id):
+        utils.exec_commandl(['ip', 'link', 'add', xfrm_name, 'type', 'xfrm', 'dev', ifname, 'if_id', xfrm_id])
 
     @staticmethod
     def route_add(route):

--- a/ifupdown2/nlmanager/nlmanager.py
+++ b/ifupdown2/nlmanager/nlmanager.py
@@ -696,6 +696,18 @@ class NetlinkManager(object):
         """
         return self._link_add(ifindex, ifname, 'macvlan', {Link.IFLA_MACVLAN_MODE: Link.MACVLAN_MODE_PRIVATE})
 
+    def link_add_xfrm(self, physdev, xfrm_ifname, xfrm_id):
+        """
+        ifindex is the index of the parent interface that this sub-interface
+        is being added to
+        """
+        ifla_info_data = {
+            Link.IFLA_XFRM_IF_ID: int(xfrm_id),
+            Link.IFLA_XFRM_LINK: int(physdev)
+        }
+        
+        return self._link_add(ifindex=None, ifname=xfrm_ifname, kind='xfrm', ifla_info_data=ifla_info_data)
+
     def vlan_get(self, filter_ifindex=None, filter_vlanid=None, compress_vlans=True):
         """
         filter_ifindex should be a tuple if interface indexes, this is a whitelist filter


### PR DESCRIPTION
It is available since Kernel 4.19 and has two parameters:

1. XFRM ID to map to an SA/SAs
2. Underlying Interface if you want to take advantage of IPSec Hardware Offload

Otherwise it is treated as a normal interface and not like a tunnel (VTI).

I added two attributes to the interface to configure it and otherwise use it as a normal interface.
One example is:

auto ipsec1
iface ipsec1 inet
	xfrm-physdev lo
	xfrmid 1

Some useful links are:

https://patchwork.ozlabs.org/patch/924821/
https://wiki.strongswan.org/projects/strongswan/wiki/RouteBasedVPN#XFRM-Interfaces-on-Linux

Best
Sven