### PR TITLE
ifreload: down/up vxlan interfaces when ifreload_down_changed=0

### DIFF
--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -2099,7 +2099,7 @@ class ifupdownMain(ifupdownBase):
                                      % (newifaceobjlist[objidx].name,
                                         ifaceLinkKind.to_str(lastifaceobjlist[0].link_kind)))
                     ifacedownlist.append(newifaceobjlist[objidx].name)
-                if not down_changed:
+                if not down_changed and ifaceLinkKind.to_str(lastifaceobjlist[0].link_kind) != 'vxlan':
                     continue
                 if len(newifaceobjlist) != len(lastifaceobjlist):
                     ifacedownlist.append(ifname)


### PR DESCRIPTION
almost all attributes of vxlan interfaces can't be updated
in current kernel (<= 5.2). (including vxlan-id)

so when ifreload_down_changed=0, ifreload can't update vxlan.

fix: https://github.com/CumulusNetworks/ifupdown2/issues/50