### PR TITLE
addons: dhcp: Policy to specify DUID type to use on dhcpv6 requests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,6 +11,7 @@ ifupdown2 (1.2.6-1) unstable; urgency=medium
   * New: link-down yes will also down macvlans
   * New: XFRM addon module
   * New: Add policy to wait for IPv6 link local address to be available
+  * New: Add policy dhcp6-duid to specify DUID type to be used for IPv6 interfaces
 
  -- Julien Fortin <julien@cumulusnetworks.com>  Sun, 23 Jun 2019 23:42:42 -1000
 

--- a/ifupdown2/addons/dhcp.py
+++ b/ifupdown2/addons/dhcp.py
@@ -68,6 +68,8 @@ class dhcp(moduleBase):
             except:
                 timeout = 10
                 pass
+            dhcp6_duid = policymanager.policymanager_api.get_iface_default(module_name=self.__class__.__name__, \
+                ifname=ifaceobj.name, attr='dhcp6-duid')
 
             vrf = ifaceobj.get_attr_value_first('vrf')
             if (vrf and self.vrf_exec_cmd_prefix and
@@ -103,7 +105,7 @@ class dhcp(moduleBase):
                         self.sysctl_set('net.ipv6.conf.%s' %ifaceobj.name +
                                 '.autoconf', autoconf)
                         try:
-                            self.dhclientcmd.stop6(ifaceobj.name)
+                            self.dhclientcmd.stop6(ifaceobj.name, duid=dhcp6_duid)
                         except:
                             pass
                     #add delay before starting IPv6 dhclient to
@@ -118,7 +120,7 @@ class dhcp(moduleBase):
                         if r:
                             self.dhclientcmd.start6(ifaceobj.name,
                                                     wait=wait,
-                                                    cmd_prefix=dhclient_cmd_prefix)
+                                                    cmd_prefix=dhclient_cmd_prefix, duid=dhcp6_duid)
                             return
                         timeout -= 1
                         if timeout:
@@ -144,8 +146,10 @@ class dhcp(moduleBase):
         if (vrf and self.vrf_exec_cmd_prefix and
             self.ipcmd.link_exists(vrf)):
             dhclient_cmd_prefix = '%s %s' %(self.vrf_exec_cmd_prefix, vrf)
+        dhcp6_duid = policymanager.policymanager_api.get_iface_default(module_name=self.__class__.__name__, \
+            ifname=ifaceobj.name, attr='dhcp6-duid')
         if 'inet6' in ifaceobj.addr_family:
-            self.dhclientcmd.release6(ifaceobj.name, dhclient_cmd_prefix)
+            self.dhclientcmd.release6(ifaceobj.name, dhclient_cmd_prefix, duid=dhcp6_duid)
         if 'inet' in ifaceobj.addr_family:
             self.dhclientcmd.release(ifaceobj.name, dhclient_cmd_prefix)
 

--- a/ifupdown2/addons/dhcp.py
+++ b/ifupdown2/addons/dhcp.py
@@ -32,6 +32,35 @@ except ImportError:
 class dhcp(moduleBase):
     """ ifupdown2 addon module to configure dhcp on interface """
 
+    _modinfo = {
+        "mhelp": "Configure dhcp",
+        "attrs": {
+            "dhcp6-duid": {
+                "help": "Override the default when selecting the type of DUID to use. By default, DHCPv6 dhclient "
+                        "creates an identifier based on the link-layer address (DUID-LL) if it is running in stateless "
+                        "mode (with -S, not requesting an address), or it creates an identifier based on the "
+                       "link-layer address plus a timestamp (DUID-LLT) if it is running in stateful mode (without -S, "
+                        "requesting an  address). When DHCPv4 is configured to use a DUID using -i option the default "
+                        "is to use a DUID-LLT. -D overrides these default, with a value of either LL or LLT.",
+               "validvals": ["LL", "LLT"],
+                "example": ["dhcp6-duid LL"]
+            },
+           "dhcp-wait": {
+                "help": "Wait or not wait and become a daemon immediately (nowait) rather than waiting until an "
+                         "IP address has been acquired. If not specified default value is true, that is to wait.",
+               "validvals": ["true", "false"],
+                "example": ["dhcp-wait false"]
+            },
+           "dhcp6-ll-wait": {
+                "help": "Overrides the default wait time before DHCPv6 client is started. During this wait time, "
+                        "ifupdown2 checks if the interface requesting an address has a valid link-local address. "
+                        "If not specified default value used is 10 seconds.",
+               "validvals": ["whole numbers"],
+                "example": ["dhcp6-ll-wait 0"]
+           }
+        }
+    }
+
     def __init__(self, *args, **kargs):
         moduleBase.__init__(self, *args, **kargs)
         self.dhclientcmd = dhclient(**kargs)

--- a/ifupdown2/ifupdownaddons/dhclient.py
+++ b/ifupdown2/ifupdownaddons/dhclient.py
@@ -85,25 +85,34 @@ class dhclient(utilsBase):
                    '%s' %ifacename]
         self._run_dhclient_cmd(cmd, cmd_prefix)
 
-    def start6(self, ifacename, wait=True, cmd_prefix=None):
+    def start6(self, ifacename, wait=True, cmd_prefix=None, duid=None):
         cmd = ['/sbin/dhclient', '-6', '-pf',
                 '/run/dhclient6.%s.pid' %ifacename, '-lf',
                 '/var/lib/dhcp/dhclient6.%s.leases' % ifacename,
                 '%s' %ifacename]
         if not wait:
             cmd.append('-nw')
+        if duid is not None:
+            cmd.append('-D')
+            cmd.append(duid)
         self._run_dhclient_cmd(cmd, cmd_prefix)
 
-    def stop6(self, ifacename, cmd_prefix=None):
+    def stop6(self, ifacename, cmd_prefix=None, duid=None):
         cmd = ['/sbin/dhclient', '-6', '-x', '-pf',
                '/run/dhclient6.%s.pid' % ifacename, '-lf',
                '/var/lib/dhcp/dhclient6.%s.leases' % ifacename,
                '%s' %ifacename]
+        if duid is not None:
+            cmd.append('-D')
+            cmd.append(duid)
         self._run_dhclient_cmd(cmd, cmd_prefix)
 
-    def release6(self, ifacename, cmd_prefix=None):
+    def release6(self, ifacename, cmd_prefix=None, duid=None):
         cmd = ['/sbin/dhclient', '-6', '-r', '-pf',
                '/run/dhclient6.%s.pid' %ifacename,
               '-lf', '/var/lib/dhcp/dhclient6.%s.leases' % ifacename,
                '%s' %ifacename]
+        if duid is not None:
+            cmd.append('-D')
+            cmd.append(duid)
         self._run_dhclient_cmd(cmd, cmd_prefix)


### PR DESCRIPTION
Add a ifupdown2 policy attribute dhcp6-duid to allow user to specify the DUID type
to be used on an IPv6 enabled interface.

Signed-off-by: Rajendra Dendukuri <rajendra.dendukuri@broadcom.com>