### PR TITLE
Fix spanning tree default documentation.

### DIFF
--- a/ifupdown2/man/ifupdown-addons-interfaces.5.rst
+++ b/ifupdown2/man/ifupdown-addons-interfaces.5.rst
@@ -238,7 +238,7 @@ EXAMPLES
 
         **required**: False
 
-        **default**: no
+        **default**: yes
 
         **validvals**: yes,on,off,no
 


### PR DESCRIPTION
The documentation states that `bridge-stp` defaults to `no`. However, this does not appear to be the case. At least not on Cumulus Linux 3.7. To reproduce, on a clean CumulusVX 3.7 VM, use the following `/etc/network/interfaces` file

```
source /etc/network/interfaces.d/*.intf

# The loopback network interface
auto lo
iface lo inet loopback

# The primary network interface
auto eth0
iface eth0 inet dhcp

auto bridge
iface bridge
  bridge-vlan-aware yes
```

Then, reloading the config and checking STP status shows that STP is in fact on.

```
$ sudo ifreload -a
$ sudo net show bridge spanning-tree bridge
Bridge info
  enabled         yes
  bridge id       8.000.CA:70:D8:A4:DB:EA
    Priority:	  32768
    Address:	  CA:70:D8:A4:DB:EA
  This bridge is root.

  designated root 8.000.CA:70:D8:A4:DB:EA
    Priority:	  32768
    Address:	  CA:70:D8:A4:DB:EA

  root port       none
  path cost     0          internal path cost   0
  max age       20         bridge max age       20
  forward delay 15         bridge forward delay 15
  tx hold count 6          max hops             20
  hello time    2          ageing time          300
  force protocol version     rstp
```