### PR TITLE
This patch fixes the XFRM addon for ifupdown2 version 2.

### DIFF
--- a/ifupdown2/addons/xfrm.py
+++ b/ifupdown2/addons/xfrm.py
@@ -41,7 +41,9 @@ except ImportError:
 
 
 class xfrm(Addon, moduleBase):
-    """  ifupdown2 addon module to create a xfrm interface """
+    """
+    ifupdown2 addon module to create a xfrm interface
+    """
     _modinfo = {
         'mhelp': 'xfrm module creates a xfrm interface for',
         'attrs': {
@@ -96,7 +98,6 @@ class xfrm(Addon, moduleBase):
         """
         # Create a xfrm device on this device and set the virtual
         # router mac and ip on it
-        link_created = False
         xfrm_ifacename = self._get_xfrm_name(ifaceobj)
         physdev = self._get_parent_ifacename(ifaceobj)
         xfrmid = self._get_xfrmid(ifaceobj)
@@ -137,6 +138,7 @@ class xfrm(Addon, moduleBase):
     def _query_check(self, ifaceobj, ifaceobjcurr):
         if not self.cache.link_exists(ifaceobj.name):
             return
+
         ifaceobjcurr.status = ifaceStatus.SUCCESS
 
     def _query_running(self, ifaceobjrunning):

--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -80,7 +80,7 @@ class IPRoute2(Cache, Requirements):
     # WORK-AROUND
     ############################################################################
 
-    def __update_cache_after_link_creation(self, ifname, kind=None):
+    def __update_cache_after_link_creation(self, ifname, kind):
         """
         WORK AROUND - when creating tunnel via iproute2 we still need to fill
         our internal cache to keep track of this interface until we receive the
@@ -95,13 +95,11 @@ class IPRoute2(Cache, Requirements):
         packet.flags = nlpacket.NLM_F_CREATE | nlpacket.NLM_F_REQUEST | nlpacket.NLM_F_ACK
         packet.body = struct.pack('Bxxxiii', socket.AF_UNSPEC, 0, 0, 0)
         packet.add_attribute(nlpacket.Link.IFLA_IFNAME, ifname)
-        if kind:
-            packet.add_attribute(nlpacket.Link.IFLA_LINKINFO, {
-                nlpacket.Link.IFLA_INFO_KIND: kind,
-                nlpacket.Link.IFLA_INFO_DATA: {}
-            })
+        packet.add_attribute(nlpacket.Link.IFLA_LINKINFO, {
+            nlpacket.Link.IFLA_INFO_KIND: kind,
+            nlpacket.Link.IFLA_INFO_DATA: {}
+        })
         packet.build_message(0, 0)
-
         # When creating a new link via netlink, we don't always wait for the kernel
         # NEWLINK notification to be cached to continue. If our request is ACKed by
         # the OS we assume that the link was successfully created. Since we aren't
@@ -334,7 +332,7 @@ class IPRoute2(Cache, Requirements):
 
     def link_add_xfrm(self, ifname, xfrm_name, xfrm_id):
         utils.exec_commandl(['ip', 'link', 'add', xfrm_name, 'type', 'xfrm', 'dev', ifname, 'if_id', xfrm_id])
-        self.__update_cache_after_link_creation(xfrm_name, None)
+        self.__update_cache_after_link_creation(xfrm_name, "xfrm")
 
     ############################################################################
     # TUNNEL

--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -80,7 +80,7 @@ class IPRoute2(Cache, Requirements):
     # WORK-AROUND
     ############################################################################
 
-    def __update_cache_after_link_creation(self, ifname, kind):
+    def __update_cache_after_link_creation(self, ifname, kind=None):
         """
         WORK AROUND - when creating tunnel via iproute2 we still need to fill
         our internal cache to keep track of this interface until we receive the
@@ -95,11 +95,13 @@ class IPRoute2(Cache, Requirements):
         packet.flags = nlpacket.NLM_F_CREATE | nlpacket.NLM_F_REQUEST | nlpacket.NLM_F_ACK
         packet.body = struct.pack('Bxxxiii', socket.AF_UNSPEC, 0, 0, 0)
         packet.add_attribute(nlpacket.Link.IFLA_IFNAME, ifname)
-        packet.add_attribute(nlpacket.Link.IFLA_LINKINFO, {
-            nlpacket.Link.IFLA_INFO_KIND: kind,
-            nlpacket.Link.IFLA_INFO_DATA: {}
-        })
+        if kind:
+            packet.add_attribute(nlpacket.Link.IFLA_LINKINFO, {
+                nlpacket.Link.IFLA_INFO_KIND: kind,
+                nlpacket.Link.IFLA_INFO_DATA: {}
+            })
         packet.build_message(0, 0)
+
         # When creating a new link via netlink, we don't always wait for the kernel
         # NEWLINK notification to be cached to continue. If our request is ACKed by
         # the OS we assume that the link was successfully created. Since we aren't
@@ -330,9 +332,9 @@ class IPRoute2(Cache, Requirements):
 
     ###
 
-    @staticmethod
-    def link_add_xfrm(ifname, xfrm_name, xfrm_id):
+    def link_add_xfrm(self, ifname, xfrm_name, xfrm_id):
         utils.exec_commandl(['ip', 'link', 'add', xfrm_name, 'type', 'xfrm', 'dev', ifname, 'if_id', xfrm_id])
+        self.__update_cache_after_link_creation(xfrm_name, None)
 
     ############################################################################
     # TUNNEL

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -2803,7 +2803,8 @@ class AttributeIFLA_LINKINFO(Attribute):
             "ipip",
             "sit",
             "ip6tnl",
-            "ip6ip6"
+            "ip6ip6",
+            "xfrm"
 
         ):
             self.log.debug('Unsupported IFLA_INFO_KIND %s' % kind)

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -2736,7 +2736,8 @@ class AttributeIFLA_LINKINFO(Attribute):
             "vti6": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_vti_to_string,
             "ipip": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_iptun_to_string,
             "sit": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_iptun_to_string,
-            "ip6tnl": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_iptun_to_string
+            "ip6tnl": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_iptun_to_string,
+            "xfrm": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_xfrm_to_string
         },
         NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_INFO_SLAVE_DATA: {
             "bridge": NetlinkPacket_IFLA_LINKINFO_Attributes.ifla_brport_to_string,


### PR DESCRIPTION
The nlpacket for XFRM had a bug, I also changed iproute2 to add
the XFRM interface to the local cache after creation.
Since XFRM has no IFLA_LINKINFO I made the argument optional.
Otherwise no further operation will be done like adding an IP.

I also removed an unecessary variable in the addon.

Signed-off-by: Sven Auhagen <sven.auhagen@voleatech,de>