### PR TITLE
This patch fixes the cache creation after a tunnel is created

### DIFF
--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -358,7 +358,7 @@ class IPRoute2(Cache, Requirements):
                     cmd.append(v)
 
         utils.exec_command("%s %s" % (utils.ip_cmd, " ".join(cmd)))
-        self.__update_cache_after_link_creation(tunnelname, mode)
+        self.__update_cache_after_link_creation(tunnelname, None)
 
     def tunnel_change(self, tunnelname, attrs=None):
         """ tunnel change function """


### PR DESCRIPTION
for ipip. It usually works just not for ipip interfaces.
It seems that not every interface has IFLA_LINKINFO data.
It is not necessary to fill those data to create a cache entry,
so I removed it from the tunnel creation.

This patch requires the xfrm patch first which makes the argument
optional.

You can reproduce the problem with this and running ifupdown2 -a

auto ipip1
iface ipip1 inet6 tunnel
        tunnel-mode ip6ip6
        tunnel-local 2001:1000:1000:1000::123
        tunnel-endpoint 2001:1000:1000:1000::124
        address 2001:1000:1000:2000::123/64

Signed-off-by: Sven Auhagen <sven.auhagen@voleatech.de>