### PR TITLE
This patch adds the ability to use an ARP IP for the bond check.

### DIFF
--- a/ifupdown2/lib/sysfs.py
+++ b/ifupdown2/lib/sysfs.py
@@ -46,6 +46,8 @@ class __Sysfs(IO, Requirements):
     __bond_netlink_to_sysfs_attr_map = {
         Link.IFLA_BOND_MODE: "mode",
         Link.IFLA_BOND_MIIMON: "miimon",
+        Link.IFLA_BOND_ARP_INTERVAL: 'arp-interval',
+        Link.IFLA_BOND_ARP_IP_TARGET: 'arp-ip-target',
         Link.IFLA_BOND_USE_CARRIER: "use_carrier",
         Link.IFLA_BOND_AD_LACP_RATE: "lacp_rate",
         Link.IFLA_BOND_XMIT_HASH_POLICY: "xmit_hash_policy",


### PR DESCRIPTION
It is only valid for balance-rr and balance-xor.

One Example is:

auto bond0
iface bond0 inet
        bond-slaves ens21 ens22
        bond-mode balance-rr
        bond-arp-interval 100
        bond-arp-ip-target 8.8.8.8
        address 10.10.10.1/24

Signed-off-by: Sven Auhagen <sven.auhagen@voleatech.de>