### PR TITLE
This also adds ipip6 to nlpacket IFLA_INFO_KIND.

### DIFF
--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -2804,6 +2804,7 @@ class AttributeIFLA_LINKINFO(Attribute):
             "sit",
             "ip6tnl",
             "ip6ip6",
+            "ipip6",
             "xfrm"
 
         ):


### PR DESCRIPTION
@julienfortin this one is also missing.