### PR TITLE
bond: add bond-primary-reselect option

### DIFF
--- a/ifupdown2/addons/bond.py
+++ b/ifupdown2/addons/bond.py
@@ -162,6 +162,15 @@ class bond(Addon, moduleBase):
                 "help": "Control which slave interface is "
                         "preferred active member",
                 "example": ["bond-primary swp1"]
+            },
+            "bond-primary-reselect": {
+                "help": "bond primary reselect",
+                "validvals": [
+                    "0", "always",
+                    "1", "better",
+                    "2", "failure",
+                ],
+                "example": ["bond-primary-reselect failure"]
             }
         }
     }
@@ -182,7 +191,9 @@ class bond(Addon, moduleBase):
         'bond-lacp-bypass-allow': Link.IFLA_BOND_AD_LACP_BYPASS,
         'bond-updelay': Link.IFLA_BOND_UPDELAY,
         'bond-downdelay': Link.IFLA_BOND_DOWNDELAY,
-        'bond-primary': Link.IFLA_BOND_PRIMARY
+        'bond-primary': Link.IFLA_BOND_PRIMARY,
+        'bond-primary-reselect': Link.IFLA_BOND_PRIMARY_RESELECT
+
     }
 
     # ifquery-check attr dictionary with callable object to translate user data to netlink format
@@ -199,6 +210,7 @@ class bond(Addon, moduleBase):
         Link.IFLA_BOND_AD_LACP_BYPASS: lambda x: int(utils.get_boolean_from_string(x)),
         Link.IFLA_BOND_UPDELAY: int,
         Link.IFLA_BOND_DOWNDELAY: int,
+        Link.IFLA_BOND_PRIMARY_RESELECT: lambda x: Link.ifla_bond_primary_reselect_tbl[x],
         # Link.IFLA_BOND_PRIMARY: self.netlink.get_ifname is added in __init__()
     }
 
@@ -220,7 +232,8 @@ class bond(Addon, moduleBase):
         ('bond-lacp-rate', Link.IFLA_BOND_AD_LACP_RATE, lambda x: int(utils.get_boolean_from_string(x))),
         ('bond-lacp-bypass-allow', Link.IFLA_BOND_AD_LACP_BYPASS, lambda x: int(utils.get_boolean_from_string(x))),
         ('bond-ad-sys-mac-addr', Link.IFLA_BOND_AD_ACTOR_SYSTEM, str),
-        ('bond-ad-actor-system', Link.IFLA_BOND_AD_ACTOR_SYSTEM, str)
+        ('bond-ad-actor-system', Link.IFLA_BOND_AD_ACTOR_SYSTEM, str),
+        ('bond-primary-reselect', Link.IFLA_BOND_PRIMARY_RESELECT, lambda x: Link.ifla_bond_primary_reselect_tbl[x])
         # ('bond-primary', Link.IFLA_BOND_PRIMARY, self.cache.get_ifindex) added in __init__()
     )
 

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -542,6 +542,21 @@ class NetlinkPacket_IFLA_LINKINFO_Attributes:
         4: 'encap3+4',
     }
 
+    ifla_bond_primary_reselect_tbl = {
+        'always': 0,
+        'better': 1,
+        'failure': 2,
+        0: 0,
+        1: 1,
+        2: 2,
+    }
+
+    ifla_bond_primary_reselect_pretty_tbl = {
+        0: 'always',
+        1: 'better',
+        2: 'failure',
+    }
+
     # =========================================
     # IFLA_INFO_SLAVE_DATA attributes for bonds
     # =========================================
@@ -1095,6 +1110,15 @@ class Attribute(object):
             sub_attr_payload,
             info_data_type,
             Link.ifla_bond_mode_tbl.get(info_data_value, 0),
+        )
+
+    @staticmethod
+    def encode_bond_primary_reselect_attribute(sub_attr_pack_layout, sub_attr_payload, info_data_type, info_data_value):
+        return Attribute.encode_one_byte_attribute(
+            sub_attr_pack_layout,
+            sub_attr_payload,
+            info_data_type,
+            Link.ifla_bond_primary_reselect_tbl.get(info_data_value, 0),
         )
 
     @staticmethod
@@ -2016,6 +2040,7 @@ class AttributeIFLA_LINKINFO(Attribute):
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_AD_LACP_BYPASS: Attribute.decode_one_byte_attribute,
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_XMIT_HASH_POLICY: Attribute.decode_one_byte_attribute,
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_NUM_PEER_NOTIF: Attribute.decode_one_byte_attribute,
+                NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_PRIMARY_RESELECT: Attribute.decode_one_byte_attribute,
 
                 # 2 bytes attributes ###########################################
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_AD_ACTOR_SYS_PRIO: Attribute.decode_two_bytes_attribute,
@@ -2421,6 +2446,9 @@ class AttributeIFLA_LINKINFO(Attribute):
 
                 # bond-xmit-hash-policy attribute ##############################
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_XMIT_HASH_POLICY: Attribute.encode_bond_xmit_hash_policy_attribute,
+
+		# bond-primary-reselect attribute ##############################
+                NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_PRIMARY_RESELECT: Attribute.encode_bond_primary_reselect_attribute,
 
                 # 2 bytes attributes ###########################################
                 NetlinkPacket_IFLA_LINKINFO_Attributes.IFLA_BOND_AD_ACTOR_SYS_PRIO: Attribute.encode_two_bytes_attribute,


### PR DESCRIPTION
This option exist in ifupdown1/ifenslave,
used for active-backup bond