### PR TITLE
nlcache: use IFA_LOCAL instead IFA_ADDRESS

### DIFF
--- a/ifupdown2/lib/nlcache.py
+++ b/ifupdown2/lib/nlcache.py
@@ -1564,10 +1564,10 @@ class _NetlinkCache:
         :param new_addr:
         :return:
         """
-        ip_with_prefix = new_addr.get_attribute_value(Address.IFA_ADDRESS)
+        ip_with_prefix = new_addr.get_attribute_value(Address.IFA_LOCAL)
 
         for index, addr in enumerate(address_list):
-            if addr.get_attribute_value(Address.IFA_ADDRESS) == ip_with_prefix:
+            if addr.get_attribute_value(Address.IFA_LOCAL) == ip_with_prefix:
                 address_list[index] = new_addr
                 return True
 
@@ -1632,11 +1632,11 @@ class _NetlinkCache:
 
                 for cache_addr in self._addr_cache[ifname][addr.version]:
                     try:
-                        if cache_addr.attributes[Address.IFA_ADDRESS].value == addr:
+                        if cache_addr.attributes[Address.IFA_LOCAL].value == addr:
                             obj_to_remove = cache_addr
                     except:
                         try:
-                            if cache_addr.attributes[Address.IFA_LOCAL].value == addr:
+                            if cache_addr.attributes[Address.IFA_ADDRESS].value == addr:
                                 obj_to_remove = cache_addr
                         except:
                             return
@@ -1652,10 +1652,10 @@ class _NetlinkCache:
             # iterate through the interface addresses
             # to find which one to remove from the cache
             try:
-                ip_version = addr_to_remove.get_attribute_value(Address.IFA_ADDRESS).version
+                ip_version = addr_to_remove.get_attribute_value(Address.IFA_LOCAL).version
             except:
                 try:
-                    ip_version = addr_to_remove.get_attribute_value(Address.IFA_LOCAL).version
+                    ip_version = addr_to_remove.get_attribute_value(Address.IFA_ADDRESS).version
                 except:
                     # print debug error
                     return
@@ -1694,10 +1694,10 @@ class _NetlinkCache:
                 intf_addresses = self._addr_cache[ifname]
 
                 for addr in intf_addresses.get(4, []):
-                    addresses.append(addr.attributes[Address.IFA_ADDRESS].value)
+                    addresses.append(addr.attributes[Address.IFA_LOCAL].value)
 
                 for addr in intf_addresses.get(6, []):
-                    addresses.append(addr.attributes[Address.IFA_ADDRESS].value)
+                    addresses.append(addr.attributes[Address.IFA_LOCAL].value)
 
                 return addresses
         except (KeyError, AttributeError):
@@ -1872,13 +1872,13 @@ class _NetlinkCache:
             with self._cache_lock:
                 for cache_addr in self._addr_cache[ifname][addr.version]:
                     try:
-                        ifa_address = cache_addr.attributes[Address.IFA_ADDRESS].value
-                        if ifa_address.ip == addr.ip and ifa_address.prefixlen == addr.prefixlen:
+                        ifa_local = cache_addr.attributes[Address.IFA_LOCAL].value
+                        if ifa_local.ip == addr.ip and ifa_local.prefixlen == addr.prefixlen:
                             return True
                     except:
                         try:
-                            ifa_local = cache_addr.attributes[Address.IFA_LOCAL].value
-                            return ifa_local.ip == addr.ip and ifa_local.prefixlen == addr.prefixlen
+                            ifa_address = cache_addr.attributes[Address.IFA_ADDRESS].value
+                            return ifa_address.ip == addr.ip and ifa_address.prefixlen == addr.prefixlen
                         except:
                             pass
         except (KeyError, AttributeError):
@@ -3056,7 +3056,6 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
             packet.flags = NLM_F_CREATE | NLM_F_REQUEST | NLM_F_ACK
             packet.family = self.IPNetwork_version_to_family.get(addr.version)
 
-            packet.add_attribute(Address.IFA_ADDRESS, addr)
             packet.add_attribute(Address.IFA_LOCAL, addr)
 
             if broadcast:
@@ -3086,6 +3085,7 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
                 packet.add_attribute(Address.IFA_ADDRESS, peer)
                 packet_prefixlen = peer.prefixlen
             else:
+                packet.add_attribute(Address.IFA_ADDRESS, addr)
                 packet_prefixlen = addr.prefixlen
 
             self.logger.info(" ".join(log_msg))


### PR DESCRIPTION
by default, IFA_ADDRESS = IFA_LOCAL
but when a peer is defined, IFA_ADDRESS = peer and IFA_LOCAL = address

This fix
https://github.com/CumulusNetworks/ifupdown2/issues/147

(I don't have tested with all kinds of interfaces, so please review && test)
