### PR TITLE
addon: openvswitch : add ovs-ports-condone-regex option

### DIFF
--- a/ifupdown2/addons/openvswitch.py
+++ b/ifupdown2/addons/openvswitch.py
@@ -63,6 +63,11 @@ class openvswitch(Addon, moduleBase):
                 'example': ['ovs_extra set bridge ${IFACE} other-config:hwaddr=00:59:cf:9c:84:3a -- br-set-external-id ${IFACE} bridge-id ${IFACE}']
 
             },
+            'ovs-ports-condone-regex': {
+                    "help": "ovs ports to ignore/condone when reloading config / removing interfaces",
+                    "required": False,
+                    "example": ["ovs-ports-condone-regex ^[a-zA-Z0-9]+_v[0-9]{1,4}$"]
+            },
         }
     }
 
@@ -94,6 +99,14 @@ class openvswitch(Addon, moduleBase):
             return ovs_ports
         return None
 
+    def _get_ovs_port_condone_regex(self, ifaceobj, get_string = False):
+        ovs_port_condone_regex = ifaceobj.get_attr_value_first('ovs-ports-condone-regex')
+        if ovs_port_condone_regex:
+            if get_string:
+                return ovs_port_condone_regex
+            return re.compile (r"%s" % ovs_port_condone_regex)
+        return None
+
     def _ovs_vsctl(self, ifaceobj, cmdlist):
 
         if cmdlist:
@@ -122,6 +135,7 @@ class openvswitch(Addon, moduleBase):
         ovsoptions = ifaceobj.get_attr_value_first ('ovs-options')
         ovsextra = ifaceobj.get_attr_value('ovs-extra')
         ovsmtu = ifaceobj.get_attr_value_first ('ovs-mtu')
+        ovsportscondoneregex = self._get_ovs_port_condone_regex(ifaceobj)
 
         cmd_list = []
 
@@ -137,11 +151,15 @@ class openvswitch(Addon, moduleBase):
             # on update, delete active ports not in the new port list
             ovs_ports = self._get_ovs_ports(ifaceobj)
             running_ovs_ports = self._get_running_ovs_ports(iface)
+
             if running_ovs_ports is not None and ovs_ports is not None:
                 missingports = list(set(running_ovs_ports) - set(ovs_ports))
 
             if missingports is not None:
                 for port in missingports:
+                    if ovsportscondoneregex and ovsportscondoneregex.match(port):
+                        self.logger.info("%s: port %s will stay enslaved as it matches with ovs-ports-condone-regex" % (ifaceobj.name, port))
+                        continue
                     cmd = "--if-exists del-port %s %s"%(iface, port)
                     cmd_list.append(cmd)
 


### PR DESCRIPTION
Like for bridge, add a option to skip delete a regex list of interfaces.
(can be usefull for hypervisor, when vm interfaces are dynamically plugged)