### PR TITLE
nllistener: increase netlink buffer to 64k

### DIFF
--- a/ifupdown2/nlmanager/nllistener.py
+++ b/ifupdown2/nlmanager/nllistener.py
@@ -44,7 +44,7 @@ class NetlinkListener(Thread):
     # As defined in asm/socket.h
     _SO_ATTACH_FILTER = 26
 
-    RECV_BUFFER = 4096  # 1024 * 1024
+    RECV_BUFFER = 65536  # 1024 * 1024
 
     def __init__(self, manager, groups, pid_offset=1, error_notification=False, rcvbuf_sz=10000000, bpf_filter=None):
         """


### PR DESCRIPTION
Currently 4k buffer is too small to handle some netlink messages

(Like bridge vlans for example, with 32k messages detected).