### PR TITLE
address: don't process_mtu if ovs-mtu is defined

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -880,6 +880,10 @@ class address(Addon, moduleBase):
                        self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
 
     def process_mtu(self, ifaceobj, ifaceobj_getfunc):
+        ovs_mtu = ifaceobj.get_attr_value_first('ovs-mtu')
+        if ovs_mtu:
+            return
+
         mtu_str = ifaceobj.get_attr_value_first('mtu')
         mtu_from_policy = False
 


### PR DESCRIPTION
Openvswitch already manage mtu if ovs-mtu is defined.
(Ovs manage mtu in userland, and sync mtu for some interfaces in kernel).

If mtu is changed by address module, before the ovs userland mtu,
this give packets drop.