### PR TITLE
address: don't process_mtu for openvswitch interfaces

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -880,6 +880,10 @@ class address(Addon, moduleBase):
                        self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
 
     def process_mtu(self, ifaceobj, ifaceobj_getfunc):
+
+        if ifaceobj.link_privflags & ifaceLinkPrivFlags.OPENVSWITCH:
+            return
+
         mtu_str = ifaceobj.get_attr_value_first('mtu')
         mtu_from_policy = False
 

--- a/ifupdown2/addons/openvswitch.py
+++ b/ifupdown2/addons/openvswitch.py
@@ -201,6 +201,9 @@ class openvswitch(Addon, moduleBase):
         self._ovs_vsctl(ifaceobj, [cmd])
 
     def get_dependent_ifacenames (self, ifaceobj, ifaceobjs_all=None):
+        if not self._is_ovs_bridge(ifaceobj):
+            return None
+        ifaceobj.link_privflags |= ifaceLinkPrivFlags.OPENVSWITCH
         return None
 
     def _up (self, ifaceobj):

--- a/ifupdown2/addons/openvswitch_port.py
+++ b/ifupdown2/addons/openvswitch_port.py
@@ -217,6 +217,8 @@ class openvswitch_port(Addon, moduleBase):
         if not self._is_ovs_port (ifaceobj):
             return None
 
+        ifaceobj.link_privflags |= ifaceLinkPrivFlags.OPENVSWITCH
+
         ovsbridge = ifaceobj.get_attr_value_first ('ovs-bridge')
         return [ovsbridge]
 

--- a/ifupdown2/ifupdown/iface.py
+++ b/ifupdown2/ifupdown/iface.py
@@ -92,6 +92,7 @@ class ifaceLinkPrivFlags():
     MGMT_INTF = 0x100000000
     SINGLE_VXLAN = 0x1000000000
     ES_BOND = 0x10000000000
+    OPENVSWITCH = 0x10000000000
 
     @classmethod
     def get_str(cls, flag):
@@ -123,6 +124,9 @@ class ifaceLinkPrivFlags():
 
         if flag & cls.ES_BOND:
             string_list.append("es bond")
+
+        if flag & cls.OPENVSWITCH:
+            string_list.append("openvswitch interface")
 
         return ", ".join(string_list)
 


### PR DESCRIPTION
Openvswitch already manage mtu if ovs-mtu is defined.
(Ovs manage mtu in userland, and sync mtu for some interfaces in kernel).

If mtu is changed by address module, before the ovs userland mtu,
this give packets drop.