### PR TITLE
Add none as valid value for bridge-ports on a bridge interface

### DIFF
--- a/ifupdown2/addons/bridge.py
+++ b/ifupdown2/addons/bridge.py
@@ -67,7 +67,7 @@ class bridge(Addon, moduleBase):
                 "help": "bridge ports",
                 "multivalue": True,
                 "required": True,
-                "validvals": ["<interface-list>"],
+                "validvals": ["<interface-list>", "none"],
                 "example": [
                     "bridge-ports swp1.100 swp2.100 swp3.100",
                     "bridge-ports glob swp1-3.100",


### PR DESCRIPTION
Readds the `none` value as a valid value for the `bridge-ports` property on a bridge. This was left out in https://github.com/CumulusNetworks/ifupdown2/commit/223ba5af1d4739ca6e1857d9c502e921bb6a3fdd but I couldn't find a reason why.