### PR TITLE
nlmanager: fix IPAddress's repr, which must return a str

### DIFF
--- a/ifupdown2/nlmanager/ipnetwork.py
+++ b/ifupdown2/nlmanager/ipnetwork.py
@@ -146,7 +146,7 @@ class IPAddress(IPNetwork):
         self.ignore_prefixlen()
 
     def __repr__(self):
-        return self._ip
+        return str(self._ip)
 
     def __raise_exception(self, ip):
         raise ValueError(


### PR DESCRIPTION
Signed-off-by: Alexandre Bruyelles <abruyelles@odiso.com>