### PR TITLE
addons: vxlan: fix vxlan-svcnodeip help text

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -51,7 +51,7 @@ class vxlan(Addon, moduleBase):
                 "example": ["vxlan-local-tunnelip 172.16.20.103"]
             },
             "vxlan-svcnodeip": {
-                "help": "vxlan id",
+                "help": "vxlan svc node id",
                 "validvals": ["<ipv4>"],
                 "example": ["vxlan-svcnodeip 172.16.22.125"]
             },


### PR DESCRIPTION
This fixes the incorrect help text for vxlans svcnodeid option

Signed-off-by: Markus Hauschild <markus@moepman.eu>