### PR TITLE
networking.service: fix start networking.service before network is marked online

### DIFF
--- a/debian/ifupdown2.networking.service
+++ b/debian/ifupdown2.networking.service
@@ -2,7 +2,8 @@
 Description=Network initialization
 Documentation=man:interfaces(5) man:ifup(8) man:ifdown(8)
 DefaultDependencies=no
-Before=shutdown.target
+After=local-fs.target network-pre.target
+Before=shutdown.target network.target network-online.target
 Conflicts=shutdown.target
 
 [Service]


### PR DESCRIPTION
In debian 10, ifupdown2 didn't ensure that it will start before network.target and network-online.target.
after local-fs.target because ifupdown2 need to read config file from local filesystem
Other network services will not start after networking.service and fail because no interface is up.
(e.g isc-dhcp-server, tftp-hpa)

In Cumulus, this patch shouldn't be a problem because all switch ports need to be up before starting console for login.
and also need to read config file in local filesystem (need "After=local-fs.target")