### PR TITLE
addons: vxlan: support ToS and udpcsum

### DIFF
--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -306,7 +306,7 @@ class IPRoute2(Cache, Requirements):
         self.__update_cache_after_link_creation(ifname, "vxlan")
 
     def link_create_vxlan(self, name, vxlanid, localtunnelip=None, svcnodeip=None,
-                          remoteips=None, learning='on', ageing=None, ttl=None, physdev=None):
+                          remoteips=None, learning='on', ageing=None, ttl=None, physdev=None, udp_csum='on', tos = None):
         if svcnodeip and remoteips:
             raise Exception("svcnodeip and remoteip are mutually exclusive")
 
@@ -333,8 +333,14 @@ class IPRoute2(Cache, Requirements):
         if learning == 'off':
             cmd.append("nolearning")
 
+        if udp_csum == 'off':
+            cmd.append("noudpcsum")
+
         if ttl is not None:
             cmd.append("ttl %s" % ttl)
+
+        if tos is not None:
+            cmd.append("tos %s" % tos)
 
         if physdev:
             cmd.append("dev %s" % physdev)

--- a/ifupdown2/lib/nlcache.py
+++ b/ifupdown2/lib/nlcache.py
@@ -2966,6 +2966,10 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
                     cmd.append("nolearning")
                 info_data[nlpacket.Link.IFLA_VXLAN_LEARNING] = int(learning)
 
+                if not udp_csum:
+                    cmd.append("noudpcsum")
+                info_data[nlpacket.Link.IFLA_VXLAN_UDP_CSUM] = int(udp_csum)
+
                 if physdev:
                     cmd.append("dev %s" % physdev)
                     info_data[nlpacket.Link.IFLA_VXLAN_LINK] = self.cache.get_ifindex(physdev)

--- a/ifupdown2/nlmanager/nlmanager.py
+++ b/ifupdown2/nlmanager/nlmanager.py
@@ -1015,7 +1015,7 @@ class NetlinkManager(object):
         return self.tx_nlpacket_get_response(nbr)
 
     def link_add_vxlan(self, ifname, vxlanid, dstport=None, local=None,
-                       group=None, learning=True, ageing=None, physdev=None, ttl=None):
+                       group=None, learning=True, ageing=None, physdev=None, ttl=None, tos=None, udp_csum=True):
 
         debug = RTM_NEWLINK in self.debug
 
@@ -1026,7 +1026,10 @@ class NetlinkManager(object):
             info_data[Link.IFLA_VXLAN_LOCAL] = local
         if group:
             info_data[Link.IFLA_VXLAN_GROUP] = group
-
+        if tos:
+            info_data[Link.IFLA_VXLAN_TOS] = int(tos)
+        
+        info_data[Link.IFLA_VXLAN_UDP_CSUM] = int(udp_csum)
         info_data[Link.IFLA_VXLAN_LEARNING] = int(learning)
         info_data[Link.IFLA_VXLAN_TTL] = ttl
 


### PR DESCRIPTION
Closes #203.

```
auto testvxlan
iface testvxlan
    vxlan-id 1947
    vxlan-tos 18
    vxlan-udp-csum no
```

```
$ sudo python ifreload --all --debug
debug: args = Namespace(all=True, currentlyup=False, CLASS=None, iflist=[], noact=False, verbose=False, debug=True, withdepends=False, perfmode=False, nocache=False, excludepats=None, usecurrentconfig=False, syslog=False, force=False, syntaxcheck=False, version=None, nldebug=False)
debug: creating ifupdown object ..
info: requesting link dump
info: requesting address dump
info: requesting netconf dump
debug: nlcache: reset errorq
debug: {'use_daemon': 'no', 'template_enable': '1', 'template_engine': 'mako', 'template_lookuppath': '/home/spost/Code/ifupdown2/etc/network/ifupdown2/templates', 'default_interfaces_configfile': '/home/spost/Code/ifupdown2/etc/network/interfaces', 'disable_cli_interfacesfile': '0', 'addon_syntax_check': '0', 'addon_scripts_support': '1', 'addon_python_modules_support': '1', 'multiple_vlan_aware_bridge_support': '0', 'ifquery_check_success_str': 'pass', 'ifquery_check_error_str': 'fail', 'ifquery_check_unknown_str': '', 'ifquery_ifacename_expand_range': '0', 'link_master_slave': '1', 'delay_admin_state_change': '0', 'ifreload_down_changed': '0', 'addr_config_squash': '0', 'ifaceobj_squash': '0', 'adjust_logical_dev_mtu': '1', 'state_dir': '/var/tmp/network/', 'no_repeats': {'bridge-vlan-aware': 'yes'}}
info: loading builtin modules from ['/home/spost/Code/ifupdown2/ifupdown2/addons', '/usr/share/ifupdown2/addons']
info: module openvswitch not loaded (module init failed: no /usr/bin/ovs-vsctl found)
info: module openvswitch_port not loaded (module init failed: no /usr/bin/ovs-vsctl found)
info: module batman_adv not loaded (module init failed: no /usr/sbin/batctl found)
debug: bridge: using reserved vlan range (0, 0)
debug: bridge: init: warn_on_untagged_bridge_absence=False
debug: bridge: init: vxlan_bridge_default_igmp_snooping=None
debug: bridge: init: arp_nd_suppress_only_on_vxlan=False
debug: bridge: init: bridge_always_up_dummy_brport=None
info: executing /sbin/sysctl net.bridge.bridge-allow-multiple-vlans
debug: bridge: init: multiple vlans allowed True
info: module mstpctl not loaded (module init failed: no /sbin/mstpctl found)
info: executing /bin/ip rule show
info: executing /bin/ip -6 rule show
info: address: using default mtu 1500
info: address: max_mtu undefined
info: executing /usr/sbin/ip vrf id
info: mgmt vrf_context = False
info: dhclient: dhclient_retry_on_failure set to 0
info: executing /bin/ip addr help
info: address metric support: OK
info: module mstpctl not loaded (module init failed: no /sbin/mstpctl found)
info: module batman_adv not loaded (module init failed: no /usr/sbin/batctl found)
info: module openvswitch_port not loaded (module init failed: no /usr/bin/ovs-vsctl found)
info: module openvswitch not loaded (module init failed: no /usr/bin/ovs-vsctl found)
info: looking for user scripts under /etc/network
info: loading scripts under /etc/network/if-pre-up.d ...
info: loading scripts under /etc/network/if-up.d ...
info: loading scripts under /etc/network/if-post-up.d ...
info: loading scripts under /etc/network/if-pre-down.d ...
info: loading scripts under /etc/network/if-down.d ...
info: loading scripts under /etc/network/if-post-down.d ...
info: 'link_master_slave' is set. slave admin state changes will be delayed till the masters admin state change.
info: using mgmt iface default prefix eth
debug: reloading interface config ..
info: processing interfaces file /home/spost/Code/ifupdown2/etc/network/interfaces
info: no interfaces to down ..
info: reload: scheduling up on interfaces: ['testvxlan']
debug: scheduling '['pre-up', 'up', 'post-up']' for ['testvxlan']
debug: dependency graph {
	testvxlan : []
}
debug: graph roots (interfaces that dont have dependents): ['testvxlan']
info: testvxlan: running ops ...
debug: testvxlan: pre-up : running module xfrm
debug: testvxlan: pre-up : running module link
debug: testvxlan: pre-up : running module ppp
debug: testvxlan: pre-up : running module bond
debug: testvxlan: pre-up : running module vlan
debug: testvxlan: pre-up : running module vxlan
info: testvxlan: set vxlan-learning on
info: testvxlan: set vxlan-port 4789
info: testvxlan: set vxlan-ttl 0
info: testvxlan: set vxlan-tos 18
info: testvxlan: set vxlan-udp_csum off
info: testvxlan: netlink: ip link add dev testvxlan type vxlan id 1947 (with attributes)
debug: attributes: {1: 1947, 7: True, 15: 4789, 5: 0, 6: 18, 18: False}
debug: testvxlan: pre-up : running module usercmds
debug: testvxlan: pre-up : running module bridge
debug: testvxlan: pre-up : running module bridgevlan
debug: testvxlan: pre-up : running module tunnel
debug: testvxlan: pre-up : running module vrf
debug: testvxlan: pre-up : running module ethtool
debug: testvxlan: pre-up : running module address
info: executing /sbin/sysctl net.mpls.conf.testvxlan.input=0
info: testvxlan: netlink: ip link set dev testvxlan up
debug: testvxlan: up : running module dhcp
debug: testvxlan: up : running module address
debug: testvxlan: up : running module addressvirtual
debug: testvxlan: up : running module usercmds
debug: testvxlan: post-up : running module usercmds
debug: testvxlan: statemanager sync state pre-up
debug: saving state ..
info: exit status 0

$ ip -d link show testvxlan
34: testvxlan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 4e:ad:6a:ea:b9:83 brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 1947 srcport 0 0 dstport 4789 tos 0x12 ttl auto ageing 300 noudpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

This seems to work for me, definitely open to suggestions!