### PR TITLE
Correct ToS value for Inherit

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -101,7 +101,7 @@ class vxlan(Addon, moduleBase):
                 "example": ['vxlan-ttl 42'],
             },
             "vxlan-tos": {
-                "help": "specifies the ToS value (range 0..255), 0=inherit",
+                "help": "specifies the ToS value (range 0..255), 1=inherit",
                 "default": "0",
                 "validvals": ["inherit", "0", "255"],
                 "example": ['vxlan-tos 42'],
@@ -249,7 +249,7 @@ class vxlan(Addon, moduleBase):
         tos = 0
         if tos_config:
             if tos_config.lower() == "inherit":
-                tos = 0
+                tos = 1
             else:
                 tos = int(tos_config)
         return tos


### PR DESCRIPTION
Following up on https://github.com/CumulusNetworks/ifupdown2/pull/204 per @MikeZappa87 's comment.

```
≽ cat etc/network/interfaces
auto testvxlan
iface testvxlan
    vxlan-id 1947
    vxlan-tos inherit
    vxlan-udp-csum no

≽ ip -d link show testvxlan
33: testvxlan: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 4e:ad:6a:ea:b9:83 brd ff:ff:ff:ff:ff:ff promiscuity 0 minmtu 68 maxmtu 65535
    vxlan id 1947 srcport 0 0 dstport 4789 tos **inherit** ttl auto ageing 300 noudpcsum noudp6zerocsumtx noudp6zerocsumrx addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535
```

Apparently ToS uses 1 for inherit. Not sure where I got 0 from!