### PR TITLE
Support value-in-range with <number> keyword

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -97,12 +97,14 @@ class vxlan(Addon, moduleBase):
                 "help": "specifies the TTL value to use in outgoing packets "
                         "(range 0..255), 0=auto",
                 "default": "0",
-                "validvals": ["0", "255"],
+                "validrange": ["0", "255"],
+                "validvals": ["<number>", "auto"],
                 "example": ['vxlan-ttl 42'],
             },
             "vxlan-tos": {
                 "help": "specifies the ToS value (range 0..255), 1=inherit",
-                "validvals": ["inherit", "0", "255"],
+                "validrange": ["0", "255"],
+                "validvals": ["<number>", "inherit"],
                 "example": ['vxlan-tos 42'],
             },
             "vxlan-mcastgrp": {

--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -1224,7 +1224,9 @@ class ifupdownMain:
 
     def _keyword_number(self, value, validrange=None):
         try:
-            int(value)
+            int_value = int(value)
+            if validrange is not None:
+                return int(validrange[0]) <= int_value <= int(validrange[1])
             return True
         except Exception as e:
             self.logger.debug('keyword: number: %s' % str(e))


### PR DESCRIPTION
This allows syntax checking to pass for fields like vxlan-ttl/vxlan-tos
which can be a number in a range OR a string value representing a special
meaning (0-255 or "auto", for instance).  Without this, you can only pass
a --syntax-check for such fields if your value is one of those literally
specified because, for instance, "64" is not "auto", "0", or "255":

```
invalid value "64": valid attribute values: ['0', '255']
info: exit status 1
```

Note that _applying_ such configuration still works, because netlink's
acceptance criteria are independent of ifupdown2's.

This should not change behavior for any other type of interface, as none use a `validrange` in combination with a `<number>` keyword.

With this interfaces file:
```
auto testvxlan1
iface testvxlan2
    vxlan-local-tunnelip 172.16.20.103
    vxlan-ttl auto
    vxlan-id 139
    vxlan-tos inherit

auto testvxlan2
iface testvxlan2
    vxlan-local-tunnelip 172.16.20.103
    vxlan-ttl 12
    vxlan-id 140
    vxlan-tos 2
```

Before:
```
$ ifreload --syntax-check --all; echo $?
warning: testvxlan2: vxlan-ttl: invalid value "auto": valid attribute values: ['0', '255']
warning: testvxlan2: vxlan-ttl: invalid value "12": valid attribute values: ['0', '255']
warning: testvxlan2: vxlan-tos: invalid value "2": valid attribute values: ['inherit', '0', '255']
1
```

After:
```
$ ifreload --syntax-check --all; echo $?
0
```