### PR TITLE
networkinterfaces: support source-directory statement

### DIFF
--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -191,10 +191,8 @@ class networkInterfaces():
 
             folders = glob.glob(sourced_directory)
             for folder in folders:
-                filenames = [file for file in os.listdir(folder) if re.match(r'^[a-zA-Z0-9_-]+$', file)]
-
-                for f in filenames:
-                    self.read_file(os.path.join(folder, f))
+                for file in os.listdir(folder):
+                    self.read_file(os.path.join(folder, file))
         else:
             self._parse_error(self._currentfile, lineno,
                               'unable to read source-directory line')

--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -161,9 +161,13 @@ class networkInterfaces():
 
     def process_source(self, lines, cur_idx, lineno):
         # Support regex
-        self.logger.debug('processing sourced line ..\'%s\'' %lines[cur_idx])
+        self.logger.debug('processing sourced line ..\'%s\'' % lines[cur_idx])
         sourced_file = re.split(self._ws_split_regex, lines[cur_idx], 2)[1]
+
         if sourced_file:
+            if not os.path.isabs(sourced_file):
+                sourced_file = os.path.join(os.path.dirname(self._currentfile), sourced_file)
+
             filenames = sorted(glob.glob(sourced_file))
             if not filenames:
                 if '*' not in sourced_file:
@@ -180,7 +184,11 @@ class networkInterfaces():
     def process_source_directory(self, lines, cur_idx, lineno):
         self.logger.debug('processing source-directory line ..\'%s\'' % lines[cur_idx])
         sourced_directory = re.split(self._ws_split_regex, lines[cur_idx], 2)[1]
+
         if sourced_directory:
+            if not os.path.isabs(sourced_directory):
+                sourced_directory = os.path.join(os.path.dirname(self._currentfile), sourced_directory)
+
             folders = glob.glob(sourced_directory)
             for folder in folders:
                 filenames = [file for file in os.listdir(folder) if re.match(r'^[a-zA-Z0-9_-]+$', file)]


### PR DESCRIPTION
This patch series implements support for the `source-directory` statement according to `interfaces(5)`. Additionally relative path handling in `source` and `source-directory` statements is fixed to match the documented behavior:


> When sourcing files or directories, if a path doesn't have a leading slash, it's considered relative to the directory containing the file in which the keyword is placed. In the example above, if the file is located at /etc/network/interfaces, paths to the included files are understood to be under /etc/network.

Excerpt from https://manpages.debian.org/buster/ifupdown/interfaces.5.en.html

Fixes #191 