### PR TITLE
debian: Run ifupdown2 after udev has settled

### DIFF
--- a/debian/ifupdown2.networking.service
+++ b/debian/ifupdown2.networking.service
@@ -4,6 +4,8 @@ Documentation=man:interfaces(5) man:ifup(8) man:ifdown(8)
 DefaultDependencies=no
 Before=shutdown.target
 Conflicts=shutdown.target
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
When renaming interfaces via udev rules, ifupdown2 isn't configuring the interfaces after a reboot, because ifupdown2 is running before the udev rules were loaded.

This change will (optionally) wait for the systemd-udev-settle service. It should have no impact on systems without udev.
