### PR TITLE
Fix adding a static IPv6 default route failed on RA networks

### DIFF
--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -819,9 +819,9 @@ class IPRoute2(Cache, Requirements):
             return
 
         if not vrf:
-            cmd = "%s route add default via %s proto kernel" % (utils.ip_cmd, gateway)
+            cmd = "%s route replace default via %s proto kernel" % (utils.ip_cmd, gateway)
         else:
-            cmd = "%s route add table %s default via %s proto kernel" % (utils.ip_cmd, vrf, gateway)
+            cmd = "%s route replace table %s default via %s proto kernel" % (utils.ip_cmd, vrf, gateway)
 
         if metric:
             cmd += " metric %s" % metric


### PR DESCRIPTION
There may be adding a static IPv6 default route failed on networks where
router advertisements are also present.

The flow of up an interface is this:
1. ip link set dev $interface up
2. set sysctl config
3. config ip addr
4. config default ip route

After setting the link up, the kernel might learning an address and a
default route from RA before the default route config. The default route
will fail to be added. If the RA route is expired, and not be refreshed
for some reasons，the system looses IPv6 network connectivity.

Proposed fix is to use "route replace" instead of "route add". When the
RA learned route is still present it gets replaced, when it is not present
the route gets added.

Signed-off-by: Kunkun Li <likunkun@bytedance.com>