### PR TITLE
Sort filenames in interfaces.d so they're parsed in a consistent order

### DIFF
--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -163,7 +163,7 @@ class networkInterfaces():
         self.logger.debug('processing sourced line ..\'%s\'' %lines[cur_idx])
         sourced_file = re.split(self._ws_split_regex, lines[cur_idx], 2)[1]
         if sourced_file:
-            filenames = glob.glob(sourced_file)
+            filenames = sorted(glob.glob(sourced_file))
             if not filenames:
                 if '*' not in sourced_file:
                     self._parse_warn(self._currentfile, lineno,


### PR DESCRIPTION
This adds sorting when reading files from /etc/network/interfaces.d.  Before this patch, the filenames are returned in random order, which results in some weird behavior.

Consider the following configs:
```
interfaces.d/eno1:

allow-hotplug eno1
auto eno1
iface eno1 inet static
        address 10.0.0.130/255.255.255.248
        mtu 1500
        gateway 10.0.0.129
        preferred-lifetime forever


interfaces.d/eno1_55:
iface eno1 inet static
        address 10.0.0.131/255.255.255.248
        preferred-lifetime 0
```

Since the current code relies on the order from glob.glob (which in turn relies on the order from the filesystem) it's likely that the eno1_55 config file will be parsed first (resulting in the 10.0.0.131 address being the "default" IP on the interface).  ifupdown2 doesn't really have a way for me to tell it to parse eno1 first before eno1_55 - but after this patch I can just name it "01-eno1" and "05-eno1_55", which results in the configs being applied in the proper order.

Another approach would probably be:
```
interfaces.d/eno1:

allow-hotplug eno1
auto eno1
iface eno1 inet static
        address 10.0.0.130/255.255.255.248
        mtu 1500
        gateway 10.0.0.129
        preferred-lifetime forever
        address 10.0.0.131/255.255.255.248
        preferred-lifetime 0
```

However, our automation system makes it significantly easier for us to drop multiple files in interfaces.d, rather then combining them all into one large file.