### PR TITLE
Dad handling

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -68,6 +68,14 @@ class address(AddonWithIpBlackList, moduleBase):
                 'example': ['netmask 255.255.255.0'],
                 'compat': True
             },
+            'dad-attempts': {
+                'help': 'Number of attempts to settle DAD (0 to disable DAD). Default value: "60"',
+                'example': ['dad-attempts 0'],
+            },
+            'dad-interval': {
+                'help': 'DAD state polling interval in seconds. Default value: "0.1"',
+                'example': ['dad-interval 0.5'],
+            },
             'broadcast': {
                 'help': 'The broadcast address on the interface.',
                 'validvals': ['<ipv4>'],

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -524,7 +524,8 @@ class address(AddonWithIpBlackList, moduleBase):
                         scope=attributes.get("scope"),
                         peer=attributes.get("pointopoint"),
                         broadcast=attributes.get("broadcast"),
-                        preferred_lifetime=attributes.get("preferred-lifetime")
+                        preferred_lifetime=attributes.get("preferred-lifetime"),
+                        nodad=attributes.get('dad-attempts') == '0'
                     )
                 else:
                     self.netlink.addr_add(ifname, ip)

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -477,10 +477,15 @@ class address(AddonWithIpBlackList, moduleBase):
                         else:
                             addr_obj = ipnetwork.IPNetwork(addr)
 
-                    for attr_name in ("broadcast", "scope", "preferred-lifetime"):
+                    for attr_name in ("broadcast", "scope", "preferred-lifetime", 'dad-attempts', 'dad-interval'):
                         attr_value = ifaceobj.get_attr_value_n(attr_name, index)
                         if attr_value:
                             addr_attributes[attr_name] = attr_value
+
+                    if addr_obj.version == 4 and any(dad in addr_attributes for dad in ('dad-attempts', 'dad-interval')):
+                        self.logger.warning("%s: dad options is only available for ipv6", ifaceobj.name)
+                        addr_attributes.pop('dad-attempts', None)
+                        addr_attributes.pop('dad-interval', None)
 
                     pointopoint = ifaceobj.get_attr_value_n("pointopoint", index)
                     try:

--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -234,7 +234,7 @@ class networkInterfaces():
         except Exception:
             pass
         attrvallist = iface_config.get(newattrname, [])
-        if newattrname in ['scope', 'netmask', 'broadcast', 'preferred-lifetime']:
+        if newattrname in ['scope', 'netmask', 'broadcast', 'preferred-lifetime', 'dad-attempts', 'dad-interval']:
             # For attributes that are related and that can have multiple
             # entries, store them at the same index as their parent attribute.
             # The example of such attributes is 'address' and its related

--- a/ifupdown2/lib/nlcache.py
+++ b/ifupdown2/lib/nlcache.py
@@ -3130,7 +3130,7 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
 
         self.log_info_ifname_dry_run(ifname, " ".join(log_msg))
 
-    def addr_add(self, ifname, addr, broadcast=None, peer=None, scope=None, preferred_lifetime=None, metric=None):
+    def addr_add(self, ifname, addr, broadcast=None, peer=None, scope=None, preferred_lifetime=None, metric=None, nodad=False):
         log_msg = ["%s: netlink: ip addr add %s dev %s" % (ifname, addr, ifname)]
         log_msg_displayed = False
         try:
@@ -3154,6 +3154,10 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
 
             packet.add_attribute(Address.IFA_ADDRESS, addr)
             packet.add_attribute(Address.IFA_LOCAL, addr)
+
+            if nodad:
+                log_msg.append("nodad")
+                packet.add_attribute(Address.IFA_FLAGS, Address.IFA_F_NODAD)
 
             if broadcast:
                 log_msg.append("broadcast %s" % broadcast)

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -3816,7 +3816,7 @@ class Address(NetlinkPacket):
         IFA_ANYCAST   : ('IFA_ANYCAST', AttributeIPAddress),
         IFA_CACHEINFO : ('IFA_CACHEINFO', AttributeCACHEINFO),
         IFA_MULTICAST : ('IFA_MULTICAST', AttributeIPAddress),
-        IFA_FLAGS     : ('IFA_FLAGS', AttributeGeneric),
+        IFA_FLAGS     : ('IFA_FLAGS', AttributeFourByteValue),
         IFA_RT_PRIORITY : ('IFA_RT_PRIORITY', AttributeFourByteValue)
     }
 


### PR DESCRIPTION
Hi,

This PR tries to resolve the dad issue mentioned in https://github.com/CumulusNetworks/ifupdown2/issues/30.

On debian (tested in bullseye and buster), services such as sshd cannot bind to a static ipv6 right after the networking service, since the defined ipv6 is in a tentative state.

This PR restore some ifupdown (original) handling on DAD.
* adding options to disable dad for an address
* adding a settle dad function to wait for a given time and warn the user in case of the ip could not be validated or timeout.

I understand that ifupdown2 is not meant to be an ifupdown clone in python, so If the default behavior changes are not well receive, we can still discuss changing the configuration attributes or implementation.