### PR TITLE
Dad handling per itf

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -187,6 +187,13 @@ class address(AddonWithIpBlackList, moduleBase):
                 'enable_l3_iface_forwarding_checks'
             )
         )
+        self.ipv6_dad_handling_enabled = utils.get_boolean_from_string(
+            policymanager.policymanager_api.get_module_globals(
+                self.__class__.__name__,
+                'ipv6_dad_handling_enabled'
+            ),
+            default=False
+        )
 
         self.default_mtu = str(self.__policy_get_default_mtu())
         self.default_mgmt_intf_mtu = self.__policy_get_mgmt_intf_mtu()

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -1132,6 +1132,8 @@ class address(AddonWithIpBlackList, moduleBase):
         # settle dad
         if not self.ipv6_dad_handling_enabled:
             return
+        if not self.cache.link_exists(ifaceobj.name):
+            return
         ifname = ifaceobj.name
         ifaceobjs = self._get_ifaceobjs(ifaceobj, ifaceobj_getfunc)
         addr_supported, user_addrs_list = self.__get_ip_addr_with_attributes(ifaceobjs, ifname)

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -69,6 +69,20 @@ class address(AddonWithIpBlackList, moduleBase):
                 'example': ['netmask 255.255.255.0'],
                 'compat': True
             },
+            'dad-attempts': {
+                'help': 'Number of attempts to settle DAD (0 to disable DAD). '
+                        'To use this feature, the ipv6_dad_handling_enabled '
+                        'module global must be set to true',
+                'example': ['dad-attempts 0'],
+                'default': '60',
+            },
+            'dad-interval': {
+                'help': 'DAD state polling interval in seconds. '
+                        'To use this feature, the ipv6_dad_handling_enabled '
+                        'module global must be set to true',
+                'example': ['dad-interval 0.5'],
+                'default': '0.1',
+            },
             'broadcast': {
                 'help': 'The broadcast address on the interface.',
                 'validvals': ['<ipv4>'],

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -505,6 +505,9 @@ class address(AddonWithIpBlackList, moduleBase):
 
     def __add_ip_addresses_with_attributes(self, ifaceobj, ifname, user_config_ip_addrs):
         ipv6_is_disabled = None
+        nodad = False
+        if self.ipv6_dad_handling_enabled:
+            nodad = ifaceobj.get_attr_value_first('dad-attempts') == '0'
         try:
             for ip, attributes in user_config_ip_addrs:
 
@@ -526,10 +529,11 @@ class address(AddonWithIpBlackList, moduleBase):
                         scope=attributes.get("scope"),
                         peer=attributes.get("pointopoint"),
                         broadcast=attributes.get("broadcast"),
-                        preferred_lifetime=attributes.get("preferred-lifetime")
+                        preferred_lifetime=attributes.get("preferred-lifetime"),
+                        nodad=nodad
                     )
                 else:
-                    self.netlink.addr_add(ifname, ip)
+                    self.netlink.addr_add(ifname, ip, nodad=nodad)
         except Exception as e:
             self.log_error(str(e), ifaceobj)
 

--- a/ifupdown2/lib/nlcache.py
+++ b/ifupdown2/lib/nlcache.py
@@ -3130,7 +3130,7 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
 
         self.log_info_ifname_dry_run(ifname, " ".join(log_msg))
 
-    def addr_add(self, ifname, addr, broadcast=None, peer=None, scope=None, preferred_lifetime=None, metric=None):
+    def addr_add(self, ifname, addr, broadcast=None, peer=None, scope=None, preferred_lifetime=None, metric=None, nodad=False):
         log_msg = ["%s: netlink: ip addr add %s dev %s" % (ifname, addr, ifname)]
         log_msg_displayed = False
         try:
@@ -3154,6 +3154,10 @@ class NetlinkListenerWithCache(nllistener.NetlinkManagerWithListener, BaseObject
 
             packet.add_attribute(Address.IFA_ADDRESS, addr)
             packet.add_attribute(Address.IFA_LOCAL, addr)
+
+            if nodad:
+                log_msg.append("nodad")
+                packet.add_attribute(Address.IFA_FLAGS, Address.IFA_F_NODAD)
 
             if broadcast:
                 log_msg.append("broadcast %s" % broadcast)

--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -3816,7 +3816,7 @@ class Address(NetlinkPacket):
         IFA_ANYCAST   : ('IFA_ANYCAST', AttributeIPAddress),
         IFA_CACHEINFO : ('IFA_CACHEINFO', AttributeCACHEINFO),
         IFA_MULTICAST : ('IFA_MULTICAST', AttributeIPAddress),
-        IFA_FLAGS     : ('IFA_FLAGS', AttributeGeneric),
+        IFA_FLAGS     : ('IFA_FLAGS', AttributeFourByteValue),
         IFA_RT_PRIORITY : ('IFA_RT_PRIORITY', AttributeFourByteValue)
     }
 


### PR DESCRIPTION
Original pull request: https://github.com/CumulusNetworks/ifupdown2/pull/230

This PR tries to resolve the dad issue mentioned in https://github.com/CumulusNetworks/ifupdown2/issues/30.

On debian (tested in bullseye and buster), services such as sshd cannot bind to a static ipv6 right after the networking service, since the defined ipv6 is in a tentative state.

This PR restore some ifupdown (original) handling on DAD.

adding options to disable dad for an address
adding a settle dad function to wait for a given time and warn the user in case of the ip could not be validated or timeout.
I understand that ifupdown2 is not meant to be an ifupdown clone in python, so If the default behavior changes are not well receive, we can still discuss changing the configuration attributes or implementation.

Some changes is worth to mention:
* add a ipv6_dad_handling_enable module global (default: false) which enable/disable the dad handling code.
* The settle dad now wait per interface instead of per ip
* The dad-attemps and dad-interval is no more sent into the ip attributes.