### PR TITLE
Fix allow classes filtering + hotplug

### DIFF
--- a/debian/ifupdown2-hotplug
+++ b/debian/ifupdown2-hotplug
@@ -1,0 +1,132 @@
+#!/bin/sh -e
+#
+# run /sbin/{ifup,ifdown} with the --allow=hotplug option.
+#
+
+PATH='/sbin:/bin:/usr/sbin:/usr/bin'
+
+if [ -x /usr/bin/logger ]; then
+	LOGGER=/usr/bin/logger
+elif [ -x /bin/logger ]; then
+	LOGGER=/bin/logger
+else
+	unset LOGGER
+fi
+
+# for diagnostics
+if [ -t 1 -a -z "$LOGGER" ] || [ ! -e '/dev/log' ]; then
+	mesg() {
+		echo "$@" >&2
+	}
+elif [ -t 1 ]; then
+	mesg() {
+		echo "$@"
+		$LOGGER -t "${0##*/}[$$]" "$@"
+	}
+else
+	mesg() {
+		$LOGGER -t "${0##*/}[$$]" "$@"
+	}
+fi
+
+if [ -z "$INTERFACE" ]; then
+    mesg "Bad ifupdown udev helper invocation: \$INTERFACE is not set"
+    exit 1
+fi
+
+check_program() {
+    [ -x $1 ] && return 0
+
+    mesg "ERROR: $1 not found. You need to install the ifupdown package."
+    mesg "ifupdown udev helper $ACTION event for $INTERFACE not handled."
+    exit 1
+}
+
+wait_for_interface() {
+    local interface=$1
+    local state
+
+    while :; do
+	read state /sys/class/net/$interface/operstate 2>/dev/null || true
+	if [ "$state" != down ]; then
+		return 0
+	fi
+	sleep 1
+    done
+}
+
+net_ifup() {
+    check_program /sbin/ifup
+
+    # exit if the interface is not configured as allow-hotplug
+    TARGET_IFACE=$(/sbin/ifquery --allow hotplug -l "$INTERFACE" || true)
+    if [ -z "$TARGET_IFACE" ]; then
+        exit 0
+    fi
+
+    if [ -d /run/systemd/system ]; then
+        exec systemctl --no-block start $(systemd-escape --template ifup@.service $TARGET_IFACE)
+    fi
+
+    wait_for_interface lo
+
+    exec ifup --allow=hotplug $INTERFACE
+}
+
+net_ifdown() {
+    check_program /sbin/ifdown
+
+    # systemd will automatically ifdown the interface on device
+    # removal by binding the instanced service to the network device
+    if [ -d /run/systemd/system ]; then
+        exit 0
+    fi
+
+    exec ifdown --allow=hotplug $INTERFACE
+}
+
+do_everything() {
+
+case "$ACTION" in
+    add)
+    # these interfaces generate hotplug events *after* they are brought up
+    case $INTERFACE in
+	ppp*|ippp*|isdn*|plip*|lo|irda*|ipsec*)
+	exit 0 ;;
+    esac
+
+    net_ifup
+    ;;
+
+    remove)
+    # the pppd persist option may have been used, so it should not be killed
+    case $INTERFACE in
+	ppp*)
+	exit 0 ;;
+    esac
+
+    net_ifdown
+    ;;
+
+    *)
+    mesg "NET $ACTION event not supported"
+    exit 1
+    ;;
+esac
+
+}
+
+# under systemd we don't do synchronous operations, so we can run in the
+# foreground; we also need to, as forked children get killed right away under
+# systemd
+if [ -d /run/systemd/system ]; then
+    do_everything
+else
+    # under sysvinit we need to fork as we start the long-running
+    # "ifup". but there, forked processes won't get killed.
+    # When udev_log="debug" stdout and stderr are pipes connected to udevd.
+    # They need to be closed or udevd will wait for this process which will
+    # deadlock with udevsettle until the timeout.
+    exec > /dev/null 2> /dev/null
+    do_everything &
+fi

--- a/debian/ifupdown2-hotplug
+++ b/debian/ifupdown2-hotplug
@@ -34,14 +34,6 @@ if [ -z "$INTERFACE" ]; then
     exit 1
 fi
 
-check_program() {
-    [ -x $1 ] && return 0
-
-    mesg "ERROR: $1 not found. You need to install the ifupdown package."
-    mesg "ifupdown udev helper $ACTION event for $INTERFACE not handled."
-    exit 1
-}
-
 wait_for_interface() {
     local interface=$1
     local state
@@ -56,17 +48,6 @@ wait_for_interface() {
 }
 
 net_ifup() {
-    check_program /sbin/ifup
-
-    # exit if the interface is not configured as allow-hotplug
-    TARGET_IFACE=$(/sbin/ifquery --allow hotplug -l "$INTERFACE" || true)
-    if [ -z "$TARGET_IFACE" ]; then
-        exit 0
-    fi
-
-    if [ -d /run/systemd/system ]; then
-        exec systemctl --no-block start $(systemd-escape --template ifup@.service $TARGET_IFACE)
-    fi
 
     wait_for_interface lo
 
@@ -74,13 +55,6 @@ net_ifup() {
 }
 
 net_ifdown() {
-    check_program /sbin/ifdown
-
-    # systemd will automatically ifdown the interface on device
-    # removal by binding the instanced service to the network device
-    if [ -d /run/systemd/system ]; then
-        exit 0
-    fi
 
     exec ifdown --allow=hotplug $INTERFACE
 }

--- a/debian/ifupdown2.install
+++ b/debian/ifupdown2.install
@@ -1,2 +1,3 @@
 etc/network/ifupdown2/addons.conf /etc/network/ifupdown2/
 etc/network/ifupdown2/ifupdown2.conf /etc/network/ifupdown2/
+debian/ifupdown2-hotplug lib/udev

--- a/debian/ifupdown2.udev
+++ b/debian/ifupdown2.udev
@@ -1,0 +1,5 @@
+# Allow rfkill for users in the netdev group
+KERNEL=="rfkill", MODE="0664", GROUP="netdev"
+
+# Handle allow-hotplug interfaces
+SUBSYSTEM=="net", ACTION=="add|remove", RUN+="ifupdown-hotplug"

--- a/debian/rules
+++ b/debian/rules
@@ -16,6 +16,8 @@ override_dh_install:
 	mkdir -p debian/ifupdown2/lib/systemd/system/
 	install --mode=644 debian/ifup@.service debian/ifupdown2/lib/systemd/system/
 
+override_dh_installudev:
+	dh_installudev --priority=80
 
 override_dh_systemd_start:
 	dh_systemd_start --name=networking --no-start

--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -1882,13 +1882,11 @@ class ifupdownMain:
 
     def _get_filtered_ifacenames_with_classes(self, auto, allow_classes, excludepats, ifacenames):
         # if user has specified ifacelist and allow_classes
-        # append the allow_classes interfaces to user
-        # ifacelist
-        filtered_ifacenames = [i for i in list(self.ifaceobjdict.keys())
+        # filter non allowed classes interfaces 
+
+        filtered_ifacenames = [i for i in list(ifacenames)
                                if self._iface_whitelisted(auto, allow_classes,
                                                           excludepats, i)]
-        filtered_ifacenames += ifacenames
-
         for intf in ifacenames:
             for obj in self.get_ifaceobjs(intf) or []:
                 obj.blacklisted = False

--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -151,6 +151,8 @@ class networkInterfaces():
 
         allow_class = words[0].split('-')[1]
         ifacenames = words[1:]
+        if allow_class == "auto":
+            self.auto_ifaces.extend(ifacenames)
 
         if self.allow_classes.get(allow_class):
             for i in ifacenames:
@@ -204,21 +206,31 @@ class networkInterfaces():
             self._parse_error(self._currentfile, lineno,
                     'invalid auto line \'%s\''%lines[cur_idx])
             return 0
+
+        if "auto" not in self.allow_classes:
+            self.allow_classes["auto"] = []
+
         for a in auto_ifaces:
             if a == 'all':
                 self.auto_all = True
+                self.allow_classes["allow"].extend(auto_ifaces)
                 break
             r = utils.parse_iface_range(a)
             if r:
                 if len(r) == 3:
                     # eg swp1.[2-4], r = "swp1.", 2, 4)
                     for i in range(r[1], r[2]+1):
-                        self.auto_ifaces.append('%s%d' %(r[0], i))
+                        ifname = '%s%d' %(r[0], i)
+                        self.auto_ifaces.append(ifname)
+                        self.allow_classes["allow"].append(ifname)
                 elif len(r) == 4:
                     for i in range(r[1], r[2]+1):
                         # eg swp[2-4].100, r = ("swp", 2, 4, ".100")
-                        self.auto_ifaces.append('%s%d%s' %(r[0], i, r[3]))
+                        ifname = '%s%d%s' %(r[0], i, r[3])
+                        self.auto_ifaces.append(ifname)
+                        self.allow_classes["auto"].append(ifname)
             self.auto_ifaces.append(a)
+            self.allow_classes["auto"].append(a)
         return 0
 
     def _add_to_iface_config(self, ifacename, iface_config, attrname,


### PR DESCRIPTION
Hi,

currently ifquery/ifup/ifdown --allow=  don't work like ifupdown1.  

It should filter interfaces when an interfaces list is provided. (as in ifupdown2 man documentation).

This patch serie also add missing udev hotplug script.
