### PR TITLE
gvgen: fix module dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Architecture: all
 Provides: ifupdown
 Conflicts: ifupdown
 Replaces: ifupdown
-Depends: ${python3:Depends}, ${misc:Depends}, iproute2
+Depends: ${python3:Depends}, ${misc:Depends}, python3-six, iproute2
 Suggests: isc-dhcp-client, bridge-utils, ethtool, python3-gvgen, python3-mako
 Description: Network Interface Management tool similar to ifupdown
  ifupdown2 is ifupdown re-written in Python. It replaces ifupdown and provides


### PR DESCRIPTION
gvgen module require the six module from python3-six package.

This new dependency is only necessary for python2/python3 cross
compatibility on dict.iteritems() (py2) vs dict.items() (py3).

ifupdown2 does not support python2 so we could replace every iteritems
occurrences to it's python3 format but this means the gvgen module will
diff from upstream.

The simplest way is to make ifupdown depends on python3-six.