### PR TITLE
distutils: fix dependency and lib replacement

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Architecture: all
 Provides: ifupdown
 Conflicts: ifupdown
 Replaces: ifupdown
-Depends: ${python3:Depends}, ${misc:Depends}, iproute2
+Depends: ${python3:Depends}, ${misc:Depends}, iproute2, python3-setuptools
 Suggests: isc-dhcp-client, bridge-utils, ethtool, python3-gvgen, python3-mako
 Description: Network Interface Management tool similar to ifupdown
  ifupdown2 is ifupdown re-written in Python. It replaces ifupdown and provides

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -9,7 +9,7 @@ import json
 import time
 import subprocess
 
-from distutils.util import strtobool
+from setuptools.dist import strtobool
 
 try:
     from ifupdown2.lib.addon import AddonWithIpBlackList


### PR DESCRIPTION
As of now, the distutils is deprecated with removal planned for
python 3.12.

The recommended way is to use setuptools which is an enhanced
alternative to distutils maintained by the python packaging authority.

This commit replace with setuptools the distutil import inserted in the
8126ef0c00eb8e2faae2cf1ca9fbaf25c10582cd commit.

This commit also update the debian control runtime dependency.

distutils: https://docs.python.org/3/library/distutils.html
setuptools: https://setuptools.pypa.io/en/latest/