### PR TITLE
Fix the return value of utils._execute_subprocess

### DIFF
--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -386,7 +386,7 @@ class utils():
         finally:
             utils.disable_subprocess_signal_forwarding(signal.SIGINT)
 
-        cmd_output_string = cmd_output.decode() if cmd_output else cmd_output
+        cmd_output_string = cmd_output.decode() if cmd_output is not None else cmd_output
 
         if cmd_returncode != 0:
             raise Exception(cls._format_error(cmd,


### PR DESCRIPTION
If the output of the subprocess is empty, then an empty <bytes> object
is returned (b''), and not decoded into an empty <string> object.
This may result in errors such as:
    info[109734]: executing /bin/ip -6 addr show eth0
    networking[109734]: error: eth0: cannot use a string pattern on a
        bytes-like object
    error[109734]: eth0: cannot use a string pattern on a bytes-like object