### PR TITLE
multi dhcp client

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -18,6 +18,7 @@ try:
     from ifupdown2.ifupdown.iface import *
     from ifupdown2.ifupdown.utils import utils
 
+    from ifupdown2.addons.dhcp import dhcp
     from ifupdown2.ifupdownaddons.dhclient import dhclient
     from ifupdown2.ifupdownaddons.modulebase import moduleBase
 
@@ -34,6 +35,7 @@ except (ImportError, ModuleNotFoundError):
     from ifupdown.iface import *
     from ifupdown.utils import utils
 
+    from addons.dhcp import dhcp
     from ifupdownaddons.dhclient import dhclient
     from ifupdownaddons.modulebase import moduleBase
 
@@ -1035,6 +1037,41 @@ class address(AddonWithIpBlackList, moduleBase):
         else:
             self.logger.warning('%s: invalid value "%s" for attribute ipv6-addrgen' % (ifaceobj.name, user_configured_ipv6_addrgen))
 
+    def _release_stale_dhcp(self, ifaceobj):
+        """ Release any stale dhcp clients.
+
+        This method won't take actions when:
+        * ifupdown2 is running in perf mode.
+        * the interface must be handled by dhcp or ppp addons.
+        * the interface has any sibling.
+
+        Returns:
+            bool: True if a client has been released, False otherwise.
+        """
+        if ifaceobj.addr_method in ["dhcp", "ppp"]:
+            return False
+        if ifupdownflags.flags.PERFMODE:
+            return False
+        if ifaceobj.flags & iface.HAS_SIBLINGS:
+            return False
+
+        ifname = ifaceobj.name
+        released = False
+        for cls in dhcp.DHCP_CLIENTS.values():
+            try:
+                client = cls()
+                if client.is_running(ifname):
+                    client.release(ifname)
+                    self.cache.force_address_flush_family(ifname, socket.AF_INET)
+                    released = True
+                elif client.is_running6(ifname):
+                    client.release6(ifname)
+                    self.cache.force_address_flush_family(ifname, socket.AF_INET6)
+                    released = True
+            except Exception:
+                pass
+        return released
+
     def _pre_up(self, ifaceobj, ifaceobj_getfunc=None):
         if not self.cache.link_exists(ifaceobj.name):
             return
@@ -1050,26 +1087,7 @@ class address(AddonWithIpBlackList, moduleBase):
         self._sysctl_config(ifaceobj)
 
         addr_method = ifaceobj.addr_method
-        force_reapply = False
-        try:
-            # release any stale dhcp addresses if present
-            if (addr_method not in ["dhcp", "ppp"]  and not ifupdownflags.flags.PERFMODE and
-                    not (ifaceobj.flags & iface.HAS_SIBLINGS)):
-                # if not running in perf mode and ifaceobj does not have
-                # any sibling iface objects, kill any stale dhclient
-                # processes
-                dhclientcmd = dhclient()
-                if dhclientcmd.is_running(ifaceobj.name):
-                    # release any dhcp leases
-                    dhclientcmd.release(ifaceobj.name)
-                    self.cache.force_address_flush_family(ifaceobj.name, socket.AF_INET)
-                    force_reapply = True
-                elif dhclientcmd.is_running6(ifaceobj.name):
-                    dhclientcmd.release6(ifaceobj.name)
-                    self.cache.force_address_flush_family(ifaceobj.name, socket.AF_INET6)
-                    force_reapply = True
-        except Exception:
-            pass
+        force_reapply = self._release_stale_dhcp(ifaceobj)
 
         self.process_mtu(ifaceobj, ifaceobj_getfunc)
         self.up_ipv6_addrgen(ifaceobj)

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -19,7 +19,6 @@ try:
     from ifupdown2.ifupdown.utils import utils
 
     from ifupdown2.addons.dhcp import dhcp
-    from ifupdown2.ifupdownaddons.dhclient import dhclient
     from ifupdown2.ifupdownaddons.modulebase import moduleBase
 
     import ifupdown2.nlmanager.ipnetwork as ipnetwork
@@ -36,7 +35,6 @@ except (ImportError, ModuleNotFoundError):
     from ifupdown.utils import utils
 
     from addons.dhcp import dhcp
-    from ifupdownaddons.dhclient import dhclient
     from ifupdownaddons.modulebase import moduleBase
 
     import nlmanager.ipnetwork as ipnetwork
@@ -1452,9 +1450,9 @@ class address(AddonWithIpBlackList, moduleBase):
 
         self.query_running_ipv6_addrgen(ifaceobjrunning)
 
-        dhclientcmd = dhclient()
-        if (dhclientcmd.is_running(ifaceobjrunning.name) or
-                dhclientcmd.is_running6(ifaceobjrunning.name)):
+        clients = (cls() for cls in dhcp.DHCP_CLIENTS.values())
+        if any(client.is_running(ifaceobjrunning.name) or
+               client.is_running6(ifaceobjrunning.name) for client in clients):
             # If dhcp is configured on the interface, we skip it
             return
 

--- a/ifupdown2/addons/dhcp.py
+++ b/ifupdown2/addons/dhcp.py
@@ -19,6 +19,7 @@ try:
     from ifupdown2.ifupdown.utils import utils
 
     from ifupdown2.ifupdownaddons.dhclient import dhclient
+    from ifupdown2.ifupdownaddons.udhcpc import udhcpc
     from ifupdown2.ifupdownaddons.modulebase import moduleBase
 except (ImportError, ModuleNotFoundError):
     from lib.addon import Addon
@@ -31,6 +32,7 @@ except (ImportError, ModuleNotFoundError):
     from ifupdown.utils import utils
 
     from ifupdownaddons.dhclient import dhclient
+    from ifupdownaddons.udhcpc import udhcpc
     from ifupdownaddons.modulebase import moduleBase
 
 
@@ -41,7 +43,7 @@ class dhcp(Addon, moduleBase):
     # this can be changed by setting the module global
     # policy: dhclient_retry_on_failure
     DHCLIENT_RETRY_ON_FAILURE = 0
-    DHCP_CLIENTS = {c.__name__: c for c in [dhclient]}
+    DHCP_CLIENTS = {c.__name__: c for c in [dhclient, udhcpc]}
 
     _modinfo = {
         'mhelp': 'setting for dhcp client',

--- a/ifupdown2/addons/dhcp.py
+++ b/ifupdown2/addons/dhcp.py
@@ -41,6 +41,21 @@ class dhcp(Addon, moduleBase):
     # this can be changed by setting the module global
     # policy: dhclient_retry_on_failure
     DHCLIENT_RETRY_ON_FAILURE = 0
+    DHCP_CLIENTS = {c.__name__: c for c in [dhclient]}
+
+    _modinfo = {
+        'mhelp': 'setting for dhcp client',
+        'attrs': {
+            'dhcp-client': {
+                'help': 'Name of dhcp client in use',
+                'validvals': list(DHCP_CLIENTS.values()),
+                'required': False,
+                'exemple': ['dhcp-client dhclient'],
+                'default': 'dhclient',
+            },
+        }
+    }
+
 
     def __init__(self, *args, **kargs):
         Addon.__init__(self)

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -16,7 +16,7 @@ import logging
 import subprocess
 import itertools
 
-from functools import partial
+from functools import partial, reduce
 from ipaddress import IPv4Address
 
 try:
@@ -574,5 +574,12 @@ class utils():
                 cls.logger.error("invalid vlan mcast grp map entry - %s (%s)" % (ventry, str(e)))
                 raise
         return vnid
+
+    @staticmethod
+    def dig(data, *args, default=None):
+        NotFoundDict = type('NoneDict', (dict,), {})
+        ret = reduce(lambda d, key: d.get(key, NotFoundDict()), args, data)
+        return default if isinstance(ret, NotFoundDict) else ret
+
 
 fcntl.fcntl(utils.DEVNULL, fcntl.F_SETFD, fcntl.FD_CLOEXEC)

--- a/ifupdown2/ifupdownaddons/dhclient.py
+++ b/ifupdown2/ifupdownaddons/dhclient.py
@@ -5,7 +5,6 @@
 #
 
 import os
-import errno
 
 try:
     from ifupdown2.ifupdown.utils import utils
@@ -19,27 +18,11 @@ class dhclient(utilsBase):
     """ This class contains helper methods to interact with the dhclient
     utility """
 
-    def _pid_exists(self, pidfilename):
-        if os.path.exists(pidfilename):
-            try:
-                return os.readlink(
-                    "/proc/%s/exe" % self.read_file_oneline(pidfilename)
-                ).endswith("dhclient")
-            except OSError as e:
-                try:
-                    if e.errno == errno.EACCES:
-                        return os.path.exists("/proc/%s" % self.read_file_oneline(pidfilename))
-                except Exception:
-                    return False
-            except Exception:
-                return False
-        return False
-
     def is_running(self, ifacename):
-        return self._pid_exists('/run/dhclient.%s.pid' %ifacename)
+        return self.pid_exists(f'/run/dhclient.{ifacename}.pid', 'dhclient')
 
     def is_running6(self, ifacename):
-        return self._pid_exists('/run/dhclient6.%s.pid' %ifacename)
+        return self.pid_exists(f'/run/dhclient6.{ifacename}.pid', 'dhclient')
 
     def _run_dhclient_cmd(self, cmd, cmd_prefix=None):
         if not cmd_prefix:

--- a/ifupdown2/ifupdownaddons/modulebase.py
+++ b/ifupdown2/ifupdownaddons/modulebase.py
@@ -518,3 +518,21 @@ class moduleBase(object):
             return -1
 
         return self._get_vlan_id_from_ifacename(ifaceobj.name)
+
+    def get_param(self, attrname, ifaceobj=None, module_name=None):
+        """
+        Get a parameter with the following priority (first is higher):
+        * first iface attribue value
+        * default policy
+        * modinfo default attribute
+        """
+        module_name = module_name or self.__class__.__name__
+        ifname = ifaceobj.name if ifaceobj else None
+        modinfo = getattr(self, '_modinfo', {})
+        policy_api = policymanager.policymanager_api
+        values = [
+            ifaceobj.get_attr_value_first(attrname) if ifaceobj else None,
+            policy_api.get_iface_default(module_name, ifname, attrname),
+            utils.dig(modinfo, 'attrs', attrname, 'default'),
+        ]
+        return next((v for v in values if v is not None), None)

--- a/ifupdown2/ifupdownaddons/udhcpc.py
+++ b/ifupdown2/ifupdownaddons/udhcpc.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+
+import os
+import signal
+import time
+
+try:
+    from ifupdown2.ifupdown.utils import utils
+    from ifupdown2.ifupdownaddons.utilsbase import utilsBase
+
+except (ImportError, ModuleNotFoundError):
+    from ifupdown.utils import utils
+    from ifupdownaddons.utilsbase import utilsBase
+
+
+class udhcpc(utilsBase):
+    """
+    This class contains helper methods to interact with udhcpc
+    """
+
+    def __init__(self, ifaceobj, *args, **kwargs):
+        utilsBase.__init__(self, *args, **kwargs)
+        self.ifaceobj = ifaceobj
+        self.hook = 'udhcpc'
+
+    def is_running(self, ifacename):
+        return self.pid_exists(f'/run/udhcpc.{ifacename}.pid', 'busybox')
+
+    def is_running6(self, ifacename):
+        return False
+
+    def _run_udhcpc_cmd(self, cmd, cmd_prefix=None):
+        cmd_aslist = cmd_prefix.split() if cmd_prefix else []
+        cmd_aslist.extend(cmd)
+        utils.exec_commandl(cmd_aslist, stdout=None, stderr=None)
+
+    def stop(self, ifacename, cmd_prefix=None):
+        if not self.is_running(ifacename):
+            return
+        with open(f'/run/udhcpc.{ifacename}.pid', 'r') as fd:
+            pid = int(fd.read())
+        os.kill(pid, signal.SIGTERM)
+        # wait until udhcpc is stopped
+        it, maxt = 0, 10
+        while self.is_running(ifacename) and it < maxt:
+            time.sleep(1)
+            it += 1
+
+    def _get_send_packets_number(self, timeout_secs=10):
+        """ Get sendable number of packets in timeout_sec """
+        # We cannot ask udhcpc to send packets until a time is reached,
+        # but we can ask udhcpc to send a number of predetermined packets
+        # to match our given time.
+
+        PACKETS_INTERVAL_SECS = 3  # default udhcpc wait in between packets
+        if timeout_secs <= 0:
+            return 0  # 0 is an unlimited packets numbers
+        return timeout_secs // PACKETS_INTERVAL_SECS
+
+    def start(self, ifacename, wait=True, cmd_prefix=None):
+        if os.path.exists('/sbin/udhcpc'):
+            cmd = ['/sbin/udhcpc']
+        else:
+            cmd = ['/usr/bin/busybox', 'udhcpc']
+        if self.lease:
+            cmd += ['-x', f'lease:{self.lease}']
+        if not wait:
+            # udhcpc can't fork without sending at least one packet.
+            # Send one packet then unlimited background discovery.
+            cmd += ['-b', '-t', '1', '-A', '0']
+        else:
+            packets = self._get_send_packets_number()
+            cmd += ['-n', '-t', str(packets)]
+        if self.hook:
+            if os.path.basename(self.hook) == self.hook:
+                cmd += ['-s', f'/usr/share/ifupdown2/dhcp_hooks/{self.hook}']
+            else:
+                cmd += ['-s', self.hook]
+        self._run_udhcpc_cmd(cmd + [
+            '-S', '-i', ifacename, '-p', f'/run/udhcpc.{ifacename}.pid'
+        ], cmd_prefix)
+
+    def release(self, ifacename, cmd_prefix=None):
+        if not self.is_running(ifacename):
+            return
+        with open(f'/run/udhcpc.{ifacename}.pid', 'r') as fd:
+            pid = int(fd.read())
+        os.kill(pid, signal.SIGUSR2)
+        self.stop(ifacename, cmd_prefix)
+
+    def start6(self, ifname, *args, **kwargs):
+        raise NotImplementedError(
+            f'{ifname}: dhcp: udhcpc does not support inet6 family'
+        )
+
+    def stop6(self, ifname, *args, **kwargs):
+        raise NotImplementedError(
+            f'{ifname}: dhcp: udhcpc does not support inet6 family'
+        )
+
+    def release6(self, ifname, *args, **kwargs):
+        raise NotImplementedError(
+            f'{ifname}: dhcp: udhcpc does not support inet6 family'
+        )

--- a/ifupdown2/ifupdownaddons/utilsbase.py
+++ b/ifupdown2/ifupdownaddons/utilsbase.py
@@ -4,7 +4,9 @@
 # Author: Roopa Prabhu, roopa@cumulusnetworks.com
 #
 
+import os
 import time
+import errno
 import logging
 
 try:
@@ -36,6 +38,21 @@ class utilsBase(object):
     def __init__(self, *args, **kargs):
         modulename = self.__class__.__name__
         self.logger = logging.getLogger('ifupdown.' + modulename)
+
+    def pid_exists(self, pidfilename, progname):
+        if os.path.exists(pidfilename):
+            pid = self.read_file_oneline(pidfilename)
+            try:
+                return os.readlink(f"/proc/{pid}/exe").endswith(progname)
+            except OSError as e:
+                try:
+                    if e.errno == errno.EACCES:
+                        return os.path.exists(f"/proc/{pid}")
+                except Exception:
+                    return False
+            except Exception:
+                return False
+        return False
 
     def write_file(self, filename, strexpr):
         try:


### PR DESCRIPTION
Add multi dhcp client support and busybox udhcpc as one available client.

isc-dhcp-client is not always a good choice in term of client capability. In my use case, I work on qmi devices that expose raw ip interfaces which is currently unsupported. (https://gitlab.isc.org/isc-projects/dhcp/-/merge_requests/66)

We do not need to change the dhcp client, dhclient is fine most of the time and luckily, the code base is more than capable of handling two clients and not much work is needed.
