### PR TITLE
Use PATH to find tools primarily

### DIFF
--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -18,6 +18,7 @@ import itertools
 
 from functools import partial
 from ipaddress import IPv4Address
+from shutil import which
 
 try:
     from ifupdown2.ifupdown.iface import *
@@ -125,6 +126,9 @@ class utils():
                 'systemctl',
                 'dpkg'
                 ]:
+        # If we can find utilities in $PATH we take them.
+        if which(cmd):
+            vars()[cmd + '_cmd'] = which(cmd)
         if os.path.exists(vars()[cmd + '_cmd']):
             continue
         for path in ['/bin/',

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -109,6 +109,7 @@ class utils():
     systemctl_cmd   = '/bin/systemctl'
     dpkg_cmd        = '/usr/bin/dpkg'
 
+
     logger.info("utils init command paths")
     for cmd in ['bridge',
                 'ip',
@@ -129,6 +130,7 @@ class utils():
         # If we can find utilities in $PATH we take them.
         if which(cmd):
             vars()[cmd + '_cmd'] = which(cmd)
+            logger.debug('%s is set to %s through PATH', cmd + "_cmd", which(cmd))
         if os.path.exists(vars()[cmd + '_cmd']):
             continue
         for path in ['/bin/',
@@ -137,8 +139,9 @@ class utils():
                      '/usr/sbin/',]:
             if os.path.exists(path + cmd):
                 vars()[cmd + '_cmd'] = path + cmd
+                logger.debug('%s is set to %s through common bin paths', cmd + "_cmd", path + cmd)
             else:
-                logger.debug('warning: path %s not found: %s won\'t be usable' % (path + cmd, cmd))
+                logger.debug('warning: path %s not found: %s won\'t be usable', path + cmd, cmd)
 
     mac_translate_tab = str.maketrans(":.-,", "    ")
 

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -128,19 +128,27 @@ class utils():
                 'dpkg'
                 ]:
         # If we can find utilities in $PATH we take them.
+        which_cmd = which(cmd)
+        var_name = cmd + '_cmd'
+
+        logger.setLevel(logging.DEBUG)
         if which(cmd):
-            vars()[cmd + '_cmd'] = which(cmd)
-            logger.debug('%s is set to %s through PATH', cmd + "_cmd", which(cmd))
-        if os.path.exists(vars()[cmd + '_cmd']):
+            vars()[var_name] = which_cmd
+            print('ASDF: %s is set to %s through PATH' % (var_name, which_cmd))
+            logger.debug('%s is set to %s through PATH', var_name, which_cmd)
+            continue
+        if os.path.exists(vars()[var_name]):
             continue
         for path in ['/bin/',
                      '/sbin/',
                      '/usr/bin/',
                      '/usr/sbin/',]:
             if os.path.exists(path + cmd):
-                vars()[cmd + '_cmd'] = path + cmd
-                logger.debug('%s is set to %s through common bin paths', cmd + "_cmd", path + cmd)
+                vars()[var_name] = path + cmd
+                print('ASDF: %s is set to %s through common bin paths' % (var_name, path + cmd))
+                logger.debug('%s is set to %s through common bin paths', var_name, path + cmd)
             else:
+                print('ASDF: warning: path %s not found: %s won\'t be usable' % (path + cmd, cmd))
                 logger.debug('warning: path %s not found: %s won\'t be usable', path + cmd, cmd)
 
     mac_translate_tab = str.maketrans(":.-,", "    ")

--- a/ifupdown2/ifupdownaddons/modulebase.py
+++ b/ifupdown2/ifupdownaddons/modulebase.py
@@ -447,7 +447,7 @@ class moduleBase(object):
     def _get_vrf_context(self):
         vrfid = 'default'
         try:
-            vrfid = utils.exec_command('/usr/sbin/ip vrf id').strip()
+            vrfid = utils.exec_command('%s vrf id' % utils.ip_cmd).strip()
         except Exception as e:
             self.logger.debug('failed to get vrf id (%s)' %str(e))
             # ignore errors


### PR DESCRIPTION
This increases flexibility for administrators being able to select their utilities themselves.

This also enables us to package ifupdown2 with Nix, which means we can deploy ifupdown2 very easily on any distribution.

Also fixed some exceptions in log calls related to the utils class.