### PR TITLE
debian: fix network targets order for systemd unit

### DIFF
--- a/debian/ifupdown2.networking.service
+++ b/debian/ifupdown2.networking.service
@@ -5,7 +5,7 @@ DefaultDependencies=no
 After=local-fs.target network-pre.target
 Before=shutdown.target network.target network-online.target
 Conflicts=shutdown.target
-Wants=systemd-udev-settle.service
+Wants=systemd-udev-settle.service network.target
 After=systemd-udev-settle.service
 
 [Service]
@@ -19,4 +19,4 @@ ExecStop=/usr/share/ifupdown2/sbin/start-networking stop
 ExecReload=/usr/share/ifupdown2/sbin/start-networking reload
 
 [Install]
-WantedBy=basic.target network.target shutdown.target
+WantedBy=basic.target network-online.target shutdown.target


### PR DESCRIPTION
This PR make `network.target` up after `ifupdown2` is finished. Before this, no service would bring up `network.target` which is a main dependency for ordering services around network.

As explain in the systemd documentation[^1], network.target is not pulled by any services. Instead, it is pulled in by the network management service, wich we are.

For further examples the ifupdown package (on bullseye) is bundled with this unit:
```service
[Unit]
Description=Raise network interfaces
Documentation=man:interfaces(5)
DefaultDependencies=no
Requires=ifupdown-pre.service
Wants=network.target
After=local-fs.target network-pre.target apparmor.service systemd-sysctl.service systemd-modules-load.service ifupdown-pre.service
Before=network.target shutdown.target network-online.target
Conflicts=shutdown.target

[Install]
WantedBy=multi-user.target
WantedBy=network-online.target

[Service]
Type=oneshot
EnvironmentFile=-/etc/default/networking
ExecStart=/sbin/ifup -a --read-environment
ExecStop=/sbin/ifdown -a --read-environment --exclude=lo
RemainAfterExit=true
TimeoutStartSec=5min

```
And systemd-networkd also work by pulling in network.target.

[^1]: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/#conceptsinsystemd