### PR TITLE
replace lockfile global by a common argument

### DIFF
--- a/ifupdown2/ifupdown/argv.py
+++ b/ifupdown2/ifupdown/argv.py
@@ -242,6 +242,10 @@ class Parse:
 
         argparser.add_argument('-V', '--version', action=VersionAction, nargs=0)
         argparser.add_argument(
+            '-L', '--lock', default='/run/network/.lock', dest='lockfile',
+            help='use lock file instead of default /run/network/.lock'
+        )
+        argparser.add_argument(
             "--nldebug",
             dest="nldebug",
             action="store_true",

--- a/ifupdown2/ifupdown/main.py
+++ b/ifupdown2/ifupdown/main.py
@@ -35,7 +35,6 @@ except (ImportError, ModuleNotFoundError):
 
 log = logging.getLogger()
 configmap_g = None
-lockfile = "/run/network/.lock"
 
 
 class Ifupdown2:
@@ -70,7 +69,7 @@ class Ifupdown2:
             self.read_config()
             self.init(stdin_buffer)
 
-            if self.op != 'query' and not utils.lockFile(lockfile):
+            if self.op != 'query' and not utils.lockFile(self.args.lockfile):
                 log.error("Another instance of this program is already running.")
                 return Status.Client.STATUS_ALREADY_RUNNING
 


### PR DESCRIPTION
In my use case, I need to run multiple instances of ifup concurrently for each network namespace (netns) I own. However, since the commit 4a888991da421bd48842dcae2122d5de3884476a, it's no more possible.

While I support the decision re-add the lockfile, I believe it would be beneficial to allow users to customize it based on their specific needs.