### PR TITLE
fix networkinterfaces processes

### DIFF
--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -160,12 +160,13 @@ class networkInterfaces():
         allow_line = lines[cur_idx]
 
         words = re.split(self._ws_split_regex, allow_line)
-        if len(words) <= 1:
-            raise Exception('invalid allow line \'%s\' at line %d'
-                            %(allow_line, lineno))
-
-        allow_class = words[0].split('-')[1]
-        ifacenames = words[1:]
+        try:
+            allow_class = words[0].split('-')[1]
+            ifacenames = words[1:]
+            if not ifacenames or not allow_class:
+                raise IndexError()
+        except IndexError:
+            raise Exception(f'invalid allow line {allow_line} at line {lineno}')
         self._add_ifaces_to_class(allow_class, ifacenames)
         return 0
 

--- a/ifupdown2/ifupdown/networkinterfaces.py
+++ b/ifupdown2/ifupdown/networkinterfaces.py
@@ -53,7 +53,6 @@ class networkInterfaces():
         Raises:
             AttributeError, KeyError """
 
-        self.auto_ifaces = []
         self.callbacks = {}
         self.auto_all = False
         self.raw = raw
@@ -62,7 +61,9 @@ class networkInterfaces():
         self.callbacks = {'iface_found' : None,
                           'validateifaceattr' : None,
                           'validateifaceobj' : None}
-        self.allow_classes = {}
+        self.allow_classes = {'auto': []}
+        # auto is only an aliases of allow-auto
+        self.auto_ifaces = self.allow_classes['auto']
         self.interfacesfile = interfacesfile
         self.interfacesfileiobuf = interfacesfileiobuf
         self.interfacesfileformat = interfacesfileformat

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -256,18 +256,12 @@ class utils():
 
     @classmethod
     def expand_iface_range(cls, name):
-        ifacenames = []
-        irange = cls.parse_iface_range(name)
-        if irange:
-            if len(irange) == 3:
-                # eg swp1.[2-4], r = "swp1.", 2, 4)
-                for i in range(irange[1], irange[2]):
-                    ifacenames.append('%s%d' %(irange[0], i))
-            elif len(irange) == 4:
-                for i in range(irange[1], irange[2]):
-                    # eg swp[2-4].100, r = ("swp", 2, 4, ".100")
-                    ifacenames.append('%s%d%s' %(irange[0], i, irange[3]))
-        return ifacenames
+        ifrange = cls.parse_iface_range(name)
+        if not ifrange:
+            return []
+        prefix, start, end = ifrange[0], ifrange[1], ifrange[2]
+        suffix = '' if len(ifrange) <= 3 else ifrange[3]
+        return [f'{prefix}{i}{suffix}' for i in range(start, end)]
 
     @classmethod
     def is_ifname_range(cls, name):

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -261,7 +261,7 @@ class utils():
             return []
         prefix, start, end = ifrange[0], ifrange[1], ifrange[2]
         suffix = '' if len(ifrange) <= 3 else ifrange[3]
-        return [f'{prefix}{i}{suffix}' for i in range(start, end)]
+        return [f'{prefix}{i}{suffix}' for i in range(start, end + 1)]
 
     @classmethod
     def is_ifname_range(cls, name):


### PR DESCRIPTION
This PR is a continuation of: https://github.com/CumulusNetworks/ifupdown2/pull/235.

This will be a series of PRs, and this is Part 1 where only the Python code is affected. The aim is to fix any potential errors or missbehavior (no breaking changes should be present). 

(Part 2 will focus on hotplug/udev handling, and Part 3 will involve reworking and questioning the arguments. Each part should be independent and merge without conflicts with the other two.)

This PR includes the following changes:
* Makes "auto" an alias for "allow-auto" (with the same handling and container).
* Fixes the range for "ifquery/up/down" for "eth[1-2]", bringing only "eth1".
* Clarifies and cleans up some code in "networkinterfaces.py" and "utils.py".
* Improves error handling for the "allow" keyword.