### PR TITLE
addons: ethtool: add rx-vlan-filter

### DIFF
--- a/ifupdown2/addons/ethtool.py
+++ b/ifupdown2/addons/ethtool.py
@@ -123,6 +123,12 @@ class ethtool(Addon, moduleBase):
                 'validvals': ['on', 'off'],
                 'default': 'varies by interface'
             },
+            'rx-vlan-filter': {
+                'help': 'RX Vlan Filter',
+                'example': ['rx-vlan-filter off'],
+                'validvals': ['on', 'off'],
+                'default': 'varies by interface'
+            },
             'ring-rx': {
                 'help': 'Ring RX Parameter',
                 'example': ['ring-rx 512'],
@@ -444,6 +450,7 @@ class ethtool(Addon, moduleBase):
         self.do_offload_settings(ifaceobj, 'ufo-offload', 'ufo')
         self.do_offload_settings(ifaceobj, 'tx-offload', 'tx')
         self.do_offload_settings(ifaceobj, 'rx-offload', 'rx')
+        self.do_offload_settings(ifaceobj, 'rx-vlan-filter', 'rx-vlan-filter')
 
     def _pre_down(self, ifaceobj):
         if not self.cache.link_exists(ifaceobj.name) or not ifaceobj.name.startswith("swp"):


### PR DESCRIPTION
some nic like mellanox connectx don't work well with vlan aware bridge && rx-vlan-filter.
(They are limited in number of vlans in hardware filtering, and break with big number of vlans like bridge-vids 2-4096)