### PR TITLE
scheduler: import traceback

### DIFF
--- a/ifupdown2/ifupdown/scheduler.py
+++ b/ifupdown2/ifupdown/scheduler.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+import traceback
 
 from collections import OrderedDict
 


### PR DESCRIPTION
if a script in /etc/network/ifup.d/ is segfaulting,

on config loading (ifup -a), ifupdown2 is stopping

ifup -a
"
info: executing2 /etc/network/if-up.d/postfix
debug: lo: up : running script /etc/network/if-up.d/resolved info: executing2 /etc/network/if-up.d/resolved
error: name 'traceback' is not defined
debug: saving state ..
info: exit status 1
"

with this fix:

debug: lo: up : running script /etc/network/if-up.d/resolved info: executing2 /etc/network/if-up.d/resolved
  File "/usr/share/ifupdown2/ifupdown/scheduler.py", line 325, in run_iface_list
    cls.run_iface_graph(ifupdownobj, ifacename, ops, parent,
  File "/usr/share/ifupdown2/ifupdown/scheduler.py", line 315, in run_iface_graph
    cls.run_iface_list_ops(ifupdownobj, ifaceobjs, ops)
  File "/usr/share/ifupdown2/ifupdown/scheduler.py", line 188, in run_iface_list_ops
    cls.run_iface_op(ifupdownobj, ifaceobj, op,
  File "/usr/share/ifupdown2/ifupdown/scheduler.py", line 150, in run_iface_op
    ifupdownobj.log_error('%s: %s %s' % (ifacename, op, str(e)))
  File "/usr/share/ifupdown2/ifupdown/ifupdownmain.py", line 226, in log_error
    raise Exception(str)
error: lo : lo: up cmd '/etc/network/if-up.d/resolved' failed: returned -11 debug: vmbr0: found dependents ['bond0']
debug: bond0: found dependents ['enp65s0d1', 'enp65s0'] info: enp65s0d1: running ops ...
...
...