### PR TITLE
bond: fix mac-address on create with first slave mac

### DIFF
--- a/ifupdown2/addons/bond.py
+++ b/ifupdown2/addons/bond.py
@@ -884,7 +884,7 @@ class bond(Addon, moduleBase):
                 ifaceobj_getfunc,
             )
 
-            if not self.bond_mac_mgmt or not link_exists or ifaceobj.get_attr_value_first("hwaddress"):
+            if not self.bond_mac_mgmt or ifaceobj.get_attr_value_first("hwaddress"):
                 return
 
             # check if the bond mac address is correctly inherited from it's


### PR DESCRIPTION
since systemd v241, bond (like bridge), are create with a random mac instead their first slave.

We already fixing it for bond on reload, but not at create

Than mean that on first reload, we'll always ifdown/ifup interface and change mac.