### PR TITLE
addons: vxlan: fix VNI filter on single VXLAN device

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -1049,7 +1049,6 @@ class vxlan(Vxlan, moduleBase):
                 self.logger.error("%s: %s (%s)" %(ifaceobj.name, vlan_vni_map, str(e)))
                 return
 
-        vnis_int = utils.ranges_to_ints(vnis)
         self.iproute2.bridge_link_update_vni_filter(ifaceobj.name, vnisd)
 
     def check_and_raise_svd_tvd_errors(self, ifaceobj):


### PR DESCRIPTION
In af8d5db22b10909ff06032f1a2acc2f745d1f65b, the transformation of `vnis` (list) to `vnisd` (dictionary) left a reference to `vnis` which is now undefined. We just remove the line as the conversion from range to ints is done earlier in the function.