### PR TITLE
fix all eth* flagged mgmt_itf

### DIFF
--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -428,7 +428,7 @@ class ifupdownMain:
     def _get_mgmt_iface_default_prefix(self):
         attr = 'mgmt_intf_prefix'
         ret = pma.get_module_globals(module_name='main', attr=attr)
-        return ret or 'eth'
+        return ret or ''
 
 
     def link_master_slave_ignore_error(self, errorstr):
@@ -811,7 +811,7 @@ class ifupdownMain:
                     (iobj.link_kind or (iobj.link_privflags & ifaceLinkPrivFlags.LOOPBACK)):
                 iobj.link_privflags |= ifaceLinkPrivFlags.LOOPBACK
 
-            if iobj.name.startswith(self.mgmt_iface_default_prefix):
+            if self.mgmt_iface_default_prefix and iobj.name.startswith(self.mgmt_iface_default_prefix):
                 self.logger.debug('%s: marking interface with mgmt flag', iobj.name)
                 iobj.link_privflags |= ifaceLinkPrivFlags.MGMT_INTF
 


### PR DESCRIPTION
### Issue:

I encountered an issue with VLAN interfaces based on eth* interfaces in ifupdown2. Currently, these interfaces are treated differently from other interface types, resulting in MTU discrepancies.

Consider the following configuration:

```conf
iface eth1 inet static
    address 1.1.1.1/32
    mtu 2000

iface eth1.1212 inet static
    address 2.2.2.2/32
```

This results in the eth1.1212 MTU being 1500 instead of 2000.

### Management Interface Handling:

What I understand is that interfaces prefixed with "eth" are considered Management Interfaces by ifupdown2 (these interfaces do not have MTU configured resulting in my issue).

Management interface prefixes are configurable in a policy JSON file. However, I believe that ens3 and eth1 interfaces should not have different default handling.

### Proposed Changes:

Now, with this PR, "None" is being configured and allowed as the Management Interface prefix, making both ens3 and eth1 behave the same way by default.

Users can then customize their policies to handle eth-prefixed interfaces as they did before.

### Additional Suggestion:

Furthermore, I think making a policy using regex might be more useful and less error-prone than a simple "startswith".
