### PR TITLE
scheduler: avoid waiting for stdout eof of /etc/network/ scripts

### DIFF
--- a/ifupdown2/ifupdown/scheduler.py
+++ b/ifupdown2/ifupdown/scheduler.py
@@ -142,7 +142,7 @@ class ifaceScheduler():
             for mname in ifupdownobj.script_ops.get(op, []):
                 ifupdownobj.logger.debug("%s: %s : running script %s" % (ifacename, op, mname))
                 try:
-                    utils.exec_command(mname, env=command_env)
+                    utils.exec_command(mname, env=command_env, stdout=False)
                 except Exception as e:
                     if "permission denied" in str(e).lower():
                         ifupdownobj.logger.warning('%s: %s %s' % (ifacename, op, str(e)))


### PR DESCRIPTION
Hi,

As mentioned in the commit message, this patch is intended to increase compatibility with ifupdown with regards to how `/etc/network/` scripts are run (see commit message for a simple example).

It also fixes an issue where a Debian 12 host hangs indefinitely on boot if current `ifupdown2` master as well as the packages `ntpsec` and `ntpsec-ntpdate` are installed.

The hang happens because `ntpsec-ntpdate` installs a script [`/etc/network/if-up.d/ntpsec-ntpdate`](https://salsa.debian.org/debian/ntpsec/-/blob/6947b7095b16f6749237cd6240f752b880ba300f/debian/ntpsec-ntpdate.if-up) -- the following excerpt is relevant:
```
#!/bin/sh
...
(
...
service="ntpsec"
...
invoke-rc.d --quiet "$service" start >/dev/null 2>&1 || true
) &
```
The `invoke-rc.d` call amounts to `systemctl start ntpsec`, so the script essentially runs `systemctl start ntpsec` in a background subshell. Unfortunately this command blocks indefinitely (see below). Since ifupdown2 waits for stdout end-of-file, it waits for the command to terminate even though it is run in a background subshell. As a result, the boot process hangs indefinitely. I presume the `systemctl start ntpsec` command blocks indefinitely because [ntpsec.service](https://salsa.debian.org/debian/ntpsec/-/blob/6947b7095b16f6749237cd6240f752b880ba300f/etc/ntpd.service) sets `Wants=network.target`, but `network.target` will only become available when `ifupdown2` finishes, which it never does. With `ifupdown` instead of `ifupdown2`, the boot does not hang as the blocking command is executed in the background.

I guess the hang issue can also be fixed by patching the unit file of `ntpsec` and/or the network script of `ntpsec-ntpdate` -- to be honest I have not dug deep enough yet to fully grasp the network script. As this PR also increases compatibility with ifupdown, I decided to send it here anyway. Let me know what you think.

Thanks and best wishes,

Friedrich