### PR TITLE
`distutils` is deprecated. `distutils.util.strtobool` needs replacement.

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -9,7 +9,28 @@ import json
 import time
 import subprocess
 
-from setuptools.dist import strtobool
+_BOOLSTRS = {
+    'y': True,
+    'yes': True,
+    't': True,
+    'true': True,
+    'on': True,
+    '1': True,
+    'n': False,
+    'no': False,
+    'f': False,
+    'false': False,
+    'off': False,
+    '0': False
+}
+
+
+def strtobool(value):
+    try:
+        return _BOOLSTRS[str(value).lower()]
+    except KeyError:
+        raise ValueError('"{}" is not a valid bool value'.format(value))
+
 
 try:
     from ifupdown2.lib.addon import AddonWithIpBlackList


### PR DESCRIPTION
Fixes #278 

As seen here: https://github.com/pypa/setuptools/blob/2384d915088b960999ca74fb81ce70bffd17b082/setuptools/dist.py#L23C6-L23C21, setuptools.dist is calling `distutils.strtobool`

--- 

As of Python 3.10, distutils has been deprecated, which results in this DeprecationWarning when using simple_settings:

```
lib/python3.10/site-packages/simple_settings/special_settings.py:5: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
    from distutils.util import strtobool
```

To eliminate this warning, PEP 632 recomends copying the implementation into your own code, or reimplementing:

https://www.python.org/dev/peps/pep-0632/#migration-advice

An alternative is to use str2bool from PyPI:

https://github.com/symonsoft/str2bool