### PR TITLE
Remove calls to logging.addLevelName() for existing log levels

### DIFF
--- a/ifupdown2/lib/log.py
+++ b/ifupdown2/lib/log.py
@@ -114,12 +114,6 @@ class LogManager:
                 sys.stderr.write("warning: syslog: %s\n" % str(e))
                 self.__syslog_handler = None
 
-        logging.addLevelName(logging.CRITICAL, "critical")
-        logging.addLevelName(logging.WARNING, "warning")
-        logging.addLevelName(logging.ERROR, "error")
-        logging.addLevelName(logging.DEBUG, "debug")
-        logging.addLevelName(logging.INFO, "info")
-
         try:
             self.__init_debug_logging()
         except Exception as e:


### PR DESCRIPTION
Calling logging.addLevelName() for existing log levels overrides the original values in Python's logging module, which then makes it incompatible with log levels assumed by SysLogHandler, see `logging.handlers.SysLogHandler.priority_map`.
This causes unexpected behavior when using SysLogHandler, basically making it print all messages to syslog with loglevel warning.
This fixes the log level inconsistency in messages such as:
```
WARNING info: eth0: enabling syslog for dhcp configuration
WARNING info: executing /bin/ip ...
WARNING info: executing /sbin/dhclient ...
```