### PR TITLE
addons: vxlan: fix compare between remote-ips and old_remote_ips

### DIFF
--- a/ifupdown2/addons/vxlan.py
+++ b/ifupdown2/addons/vxlan.py
@@ -1244,7 +1244,7 @@ class vxlan(Vxlan, moduleBase):
         # purge any removed remote ip
         old_remoteips = self.get_old_remote_ips(ifaceobj.name)
 
-        if vxlan_purge_remotes or remoteips or (remoteips != old_remoteips):
+        if vxlan_purge_remotes or (isinstance(remoteips,list) and remoteips != old_remoteips):
             # figure out the diff for remotes and do the bridge fdb updates
             # only if provisioned by user and not by an vxlan external
             # controller.


### PR DESCRIPTION
fix regression from
https://github.com/CumulusNetworks/ifupdown2/commit/35a4278ffb588ddd9e610f9395853ff35923c069

remote-ips can be None (with evpn for example) but old_remote_ips is an empty list. So the condition is always matching