### PR TITLE
address: allow ip|ip6-forward on bridge

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -912,7 +912,7 @@ class address(AddonWithIpBlackList, moduleBase):
 
         if (ifaceobj.link_kind & ifaceLinkKind.BRIDGE):
             self._set_bridge_forwarding(ifaceobj)
-            return
+
         if not self.syntax_check_sysctls(ifaceobj):
             return
         if not self.syntax_check_l3_svi_ip_forward(ifaceobj):


### PR DESCRIPTION
Currently, a bridge always have forward enabled if an ip exist, or disabled if not ip is present.

we can't use ip-forward on|off to override it because of this return.