### PR TITLE
Backport DAD handling to the `stable` branch

### DIFF
--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -798,7 +798,7 @@ class address(moduleBase):
                     if not setting_default_value:
                         ifaceobj.status = ifaceStatus.ERROR
                         self.logger.error('%s: %s' %(ifaceobj.name, str(e)))
-        
+
     def process_mtu(self, ifaceobj, ifaceobj_getfunc):
         mtu = ifaceobj.get_attr_value_first('mtu')
 

--- a/ifupdown2/addons/address.py
+++ b/ifupdown2/addons/address.py
@@ -369,7 +369,7 @@ class address(moduleBase):
 
                 if attrs:
                     try:
-                        attrs['nodad'] = bool(attrs['nodad'])
+                        attrs['nodad'] = bool(int(attrs['nodad']))
                     except KeyError:
                         pass
                     newaddr_attrs[newaddr]= attrs
@@ -379,6 +379,10 @@ class address(moduleBase):
         for addr_index in range(0, len(newaddrs)):
             try:
                 if newaddr_attrs:
+                    if ifaceobj.addr_family[addr_index] == "inet6":
+                        nodad = newaddr_attrs.get(newaddrs[addr_index], {}).get('nodad')
+                    else:
+                        nodad = False
                     self.ipcmd.addr_add(ifaceobj.name, newaddrs[addr_index],
                         newaddr_attrs.get(newaddrs[addr_index],
                                           {}).get('broadcast'),
@@ -388,8 +392,7 @@ class address(moduleBase):
                                           {}).get('scope'),
                         newaddr_attrs.get(newaddrs[addr_index],
                                           {}).get('preferred-lifetime'),
-                        newaddr_attrs.get(newaddrs[addr_index],
-                                          {}).get('nodad'))
+                        nodad=nodad)
                 else:
                     self.ipcmd.addr_add(ifaceobj.name, newaddrs[addr_index])
             except Exception, e:
@@ -1263,7 +1266,7 @@ class address(moduleBase):
                 ifaceobj.name, what
             ]))
             addr_infos = (x for t in raw for x in t.get('addr_info', []))
-            ip_list = [f'{x["local"]}/{x["prefixlen"]}' for x in addr_infos if x]
+            ip_list = ['%s/%s' % (x["local"], {x["prefixlen"]}) for x in addr_infos if x]
             return ip_list
 
         def get_param(key, default=None):

--- a/ifupdown2/ifupdown/policymanager.py
+++ b/ifupdown2/ifupdown/policymanager.py
@@ -177,7 +177,6 @@ class policymanager():
         We first check the user_policy_array and return that value. But if
         the user did not specify an override, we use the system_policy_array.
         '''
-
         if (not attr or not module_name):
             return None
         # users can specify defaults to override the systemwide settings

--- a/ifupdown2/ifupdownaddons/LinkUtils.py
+++ b/ifupdown2/ifupdownaddons/LinkUtils.py
@@ -865,12 +865,12 @@ class LinkUtils(utilsBase):
             cmd += ' scope %s' % scope
         if preferred_lifetime:
             cmd += ' preferred_lft %s' % preferred_lifetime
-        if nodad:
-            cmd += ' nodad'
         cmd += ' dev %s' % ifacename
 
         if metric:
             cmd += ' metric %s' % metric
+        if nodad:
+            cmd += ' nodad'
 
         if LinkUtils.ipbatch and not LinkUtils.ipbatch_pause:
             self.add_to_batch(cmd)

--- a/ifupdown2/ifupdownaddons/LinkUtils.py
+++ b/ifupdown2/ifupdownaddons/LinkUtils.py
@@ -853,7 +853,7 @@ class LinkUtils(utilsBase):
 
     def addr_add(self, ifacename, address, broadcast=None,
                  peer=None, scope=None, preferred_lifetime=None, metric=None,
-                 nodad=False):
+                 nodad=None):
         if not address:
             return
         cmd = 'addr add %s' % address
@@ -869,6 +869,7 @@ class LinkUtils(utilsBase):
 
         if metric:
             cmd += ' metric %s' % metric
+
         if nodad:
             cmd += ' nodad'
 

--- a/ifupdown2/ifupdownaddons/LinkUtils.py
+++ b/ifupdown2/ifupdownaddons/LinkUtils.py
@@ -852,7 +852,8 @@ class LinkUtils(utilsBase):
                                         '-o', '-d', 'link', 'show'])
 
     def addr_add(self, ifacename, address, broadcast=None,
-                 peer=None, scope=None, preferred_lifetime=None, metric=None):
+                 peer=None, scope=None, preferred_lifetime=None, metric=None,
+                 nodad=False):
         if not address:
             return
         cmd = 'addr add %s' % address
@@ -864,6 +865,8 @@ class LinkUtils(utilsBase):
             cmd += ' scope %s' % scope
         if preferred_lifetime:
             cmd += ' preferred_lft %s' % preferred_lifetime
+        if nodad:
+            cmd += ' nodad'
         cmd += ' dev %s' % ifacename
 
         if metric:
@@ -1022,7 +1025,7 @@ class LinkUtils(utilsBase):
 
         return running_ipobj == (ip4 + ip6)
 
-    def addr_add_multiple(self, ifaceobj, ifacename, addrs, purge_existing=False, metric=None):
+    def addr_add_multiple(self, ifaceobj, ifacename, addrs, purge_existing=False, metric=None, nodad=False):
         # purges address
         if purge_existing:
             # if perfmode is not set and also if iface has no sibling
@@ -1049,7 +1052,7 @@ class LinkUtils(utilsBase):
                 self.logger.warning('%s: %s' % (ifacename, str(e)))
         for a in addrs:
             try:
-                self.addr_add(ifacename, a, metric=metric)
+                self.addr_add(ifacename, a, metric=metric, nodad=nodad)
             except Exception, e:
                 self.logger.error(str(e))
 


### PR DESCRIPTION
This brings backports the functionality of #232 back to the `stable` branch so it can be used soon. 


We were experiencing issues on our Debian 10 hosts similar to those in https://github.com/CumulusNetworks/ifupdown2/issues/30 where `up route add ...` on IPv6 interfaces would fail due to the address still being in a tentative state when the command is ran. I saw the DAD features were added in https://github.com/CumulusNetworks/ifupdown2/pull/232 but those are on the `master` branch which seems (for me at least) to be broken and probably in the middle of a rewrite. 

I only have one outstanding issue that I can think of at the moment, shown below. Thanks!

## Testing
- [x] without enabling `ipv6_dad_handling_enabled` in a policyconfig file such as `/etc/network/ifupdown2/policy.d/dad.json` the logic operates as it does currently
- [x] Enabling the feature flag in the above file path does enable the logic. Contents to enable the feature:
    ```
    {
        "address": {
                "module_globals": {
                        "ipv6_dad_handling_enabled": "yes"
                }
        }
    }
    ```
   - [x] With no additional config, all IPv6 addresses in network config are waited on for the default period (60x 0.1s)
   - [x] Adding the `dad-attempts` and/or `dad-interval` to a config file on any address will be picked up correctly
       - [ ] Only the first value is picked up here, you can specify it more than once and further instances are ignored. Of course only one value can be used but perhaps there is a better way to deal with this? Seems like the parent change would have this issue also so I don't think it's a big deal.
   - [x] Any address can have `dad-attempts 0` set which will forcibly bring up the address with `nodad`, even if `dad-attempts` is set somewhere else