### PR TITLE
Replaced readfp function with read_file for new version of configparser

### DIFF
--- a/ifupdown2/ifupdown/main.py
+++ b/ifupdown2/ifupdown/main.py
@@ -138,7 +138,7 @@ class Ifupdown2:
         configStr = '[ifupdown2]\n' + config
         configFP = io.StringIO(configStr)
         parser = configparser.RawConfigParser()
-        parser.readfp(configFP)
+        parser.read_file(configFP)
         configmap_g = dict(parser.items('ifupdown2'))
 
         # Preprocess config map


### PR DESCRIPTION
The readfp function from the RawConfigParser is obsolete and should be replaced by read_file.