### PR TITLE
ignore dpkg files when running hook scripts

### DIFF
--- a/ifupdown2/ifupdown/ifupdownmain.py
+++ b/ifupdown2/ifupdown/ifupdownmain.py
@@ -1540,7 +1540,9 @@ class ifupdownMain:
             try:
                 module_list = os.listdir(msubdir)
                 for module in module_list:
-                    if self.modules.get(module) or module in self.overridden_ifupdown_scripts:
+                    if (self.modules.get(module)
+                        or module in self.overridden_ifupdown_scripts
+                        or utils.is_dpkg_file(module)):
                         continue
                     self.script_ops[op].append(msubdir + '/' + module)
             except Exception:

--- a/ifupdown2/ifupdown/utils.py
+++ b/ifupdown2/ifupdown/utils.py
@@ -212,6 +212,12 @@ class utils():
         # what we have in the cache (data retrieved via a netlink dump by
         # nlmanager). nlmanager return all macs in lower-case
 
+    _dpkg_suffixes = (".dpkg-old", ".dpkg-dist", ".dpkg-new", ".dpkg-tmp")
+
+    @staticmethod
+    def is_dpkg_file(name):
+        return any(name.endswith(suffix) for suffix in utils._dpkg_suffixes)
+
     @classmethod
     def importName(cls, modulename, name):
         """ Import a named object """


### PR DESCRIPTION
Currently ifupdown2 executes scripts that are backed up by dpkg (e.g. foo.dpkg-old). This can lead to issues with hook scripts getting executed after upgrading ifupdown2 via dpkg, even though they should not be executed.

This also brings ifupdown2 closer on par with the behavior of ifupdown, which did not execute hook scripts with dpkg suffixes.

-------

We had the following issue occur a few times:

- Suppose there is a legacy Debian host with `ifupdown` and `ifenslave` installed that has a bond configured in `/etc/network/interfaces`.
- `ifenslave` installs a script `/etc/network/if-pre-up.d/ifenslave`.
- Now, an upgrade creates a second script `/etc/network/if-pre-up.d/ifenslave.dpkg-new`. As `ifupdown` executes network scripts via `run-parts` which ignores scripts with `.` in their name, `ifenslave.dpkg-new` has no effect.
- If the host switches over to `ifupdown2` by installing it (removing `ifupdown`, keeping `ifenslave`) and reboots, the network will not come up:
  - `/etc/network/if-pre-up.d/ifenslave` still exists, but is ignored by ifupdown2's bond addon [1]
  - `/etc/network/if-pre-up.d/ifenslave.dpkg-new` is executed by `ifupdown2` because it executes *all* scripts in `/etc/network/if-pre-up.d`, even if their name contains a dot

This leads to broken network configuration on upgrades, where users did have no network.

[1] https://github.com/CumulusNetworks/ifupdown2/blob/ccdc386cfab70703b657fe7c0ffceb95448a9c2b/ifupdown2/addons/bond.py#L45
