### PR TITLE
Bug #296: python 3.12 compability

### DIFF
--- a/ifupdown2/ifupdown/main.py
+++ b/ifupdown2/ifupdown/main.py
@@ -138,7 +138,7 @@ class Ifupdown2:
         configStr = '[ifupdown2]\n' + config
         configFP = io.StringIO(configStr)
         parser = configparser.RawConfigParser()
-        parser.readfp(configFP)
+        parser.read_file(configFP)
         configmap_g = dict(parser.items('ifupdown2'))
 
         # Preprocess config map


### PR DESCRIPTION
Since python 3.2, readfp needs to be replaced by read_file. Python 3.12 dropped the readfp function.

Patch provided as PR by me, as the original reporter failed to do so since 4-4-2024 and my systems break due to this issue.