### PR TITLE
ip6gretap tunnel creation fails since "ip tunnel" command does not know about mode "ip6gretap" while link type does, same as it was with gretap over IPv4 bevore.

### DIFF
--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -454,7 +454,7 @@ class IPRoute2(Cache, Requirements):
         if "6" in mode:
             cmd.append("-6")
 
-        if mode in ["gretap"]:
+        if mode in ["gretap", "ip6gretap"]:
             cmd.append("link %s %s type %s" % (op, tunnelname, mode))
         else:
             cmd.append("tunnel %s %s mode %s" % (op, tunnelname, mode))


### PR DESCRIPTION
Hello,

I came across an error with creation of ip6gretap tunnel type and have simply “fixed” it as in the old way. as a result, the tunnel creation now also works:

before:
```bash
info: tun6-1: running ops ...
debug: tun6-1: pre-up : running module xfrm
debug: tun6-1: pre-up : running module link
debug: tun6-1: pre-up : running module bond
debug: tun6-1: pre-up : running module vlan
debug: tun6-1: pre-up : running module vxlan
debug: tun6-1: pre-up : running module usercmds
debug: tun6-1: pre-up : running module bridge
info: tun6-1: not enslaved to bridge tun6: ignored for now
debug: tun6-1: pre-up : running module bridgevlan
debug: tun6-1: pre-up : running module tunnel
info: executing /bin/ip -6 tunnel add tun6-1 mode ip6gretap local XXXX remote XXXX
error: cmd '/bin/ip -6 tunnel add tun6-1 mode ip6gretap local XXXX remote XXXX' failed: returned 255 (Unknown tunnel mode "ip6gretap"
)
debug: tun6-1: pre-up : running module vrf
debug: tun6-1: pre-up : running module ethtool
debug: tun6-1: pre-up : running module address
debug: tun6-1: up : running module dhcp
debug: tun6-1: up : running module address
debug: tun6-1: up : running module addressvirtual
debug: tun6-1: up : running module usercmds
debug: tun6-1: up : running script /etc/network/if-up.d/resolved
info: executing /etc/network/if-up.d/resolved
debug: tun6-1: post-up : running module usercmds
debug: tun6-1: statemanager sync state pre-up
debug: saving state ..
info: exit status 1
```

after:
```bash
info: tun6-1: running ops ...
debug: tun6-1: pre-up : running module xfrm
debug: tun6-1: pre-up : running module link
debug: tun6-1: pre-up : running module bond
debug: tun6-1: pre-up : running module vlan
debug: tun6-1: pre-up : running module vxlan
debug: tun6-1: pre-up : running module usercmds
debug: tun6-1: pre-up : running module bridge
info: tun6-1: not enslaved to bridge tun6: ignored for now
debug: tun6-1: pre-up : running module bridgevlan
debug: tun6-1: pre-up : running module tunnel
info: executing /bin/ip -6 link add tun6-1 type ip6gretap local XXXX remote XXXX
debug: tun6-1: pre-up : running module vrf
debug: tun6-1: pre-up : running module ethtool
debug: tun6-1: pre-up : running module address
info: executing /sbin/sysctl net.mpls.conf.tun6-1.input=0
info: writing "1442" to file /sys/class/net/tun6-1/mtu
info: tun6-1: netlink: ip link set dev tun6-1 up
debug: tun6-1: up : running module dhcp
debug: tun6-1: up : running module address
debug: tun6-1: up : running module addressvirtual
debug: tun6-1: up : running module usercmds
debug: tun6-1: up : running script /etc/network/if-up.d/resolved
``

the problem is that the "ip tunnel" command does not know about any gretap mode, while link does.

tunnel changes also work.

I compiled my own deb with `make deb` and verified the change and it definitely works!