### PR TITLE
nlpacket: recognize 'wireguard' as valid IFLA_INFO_KIND value

### DIFF
--- a/ifupdown2/nlmanager/nlpacket.py
+++ b/ifupdown2/nlmanager/nlpacket.py
@@ -2966,8 +2966,8 @@ class AttributeIFLA_LINKINFO(Attribute):
             "ip6ip6",
             "ipip6",
             "xfrm",
-            "openvswitch"
-
+            "openvswitch",
+            "wireguard"
         ):
             self.log.debug('Unsupported IFLA_INFO_KIND %s' % kind)
             return


### PR DESCRIPTION
Pretty much as it says on the tin.

It's supported in-kernel now since 5.6 and enables creation of WireGuard interfaces through the `link-type` attribute.

Can then be used to (pre-)create wireguard interfaces like:

```
auto wg-test
iface wg-test inet static
        link-type wireguard
        address 10.210.0.1/24
        mtu 1420
```