### PR TITLE
Fix error in ifquery -c -o json <tunnel interface>

### DIFF
--- a/ifupdown2/ifupdown/iface.py
+++ b/ifupdown2/ifupdown/iface.py
@@ -320,7 +320,7 @@ class ifaceJsonEncoderWithStatus(json.JSONEncoder):
                         status_str = ifaceStatusUserStrs.UNKNOWN
                     vitem_status.append('%s' %status_str)
                     idx += 1
-                retconfig[k] = v[0] if len(v) == 1 else v
+                retconfig[k] = str(v[0] if len(v) == 1 else v)
                 retconfig_status[k] = vitem_status[0] if len(vitem_status) == 1 else vitem_status
 
         if (o.status == ifaceStatus.NOTFOUND or


### PR DESCRIPTION
In ifupdown/iface.py, class ifaceJsonEncoderWithStatus(json.JSONEncoder), in the for-loop, it fails for the IPNetwork objects (keys tunnel-endpoint and tunnel-remote) since they are not of type string. Converting the value(s) to string in the loop resolved it.

```
$ ifquery -c -o json gre1
error: main exception: 'IPNetwork' object has no attribute 'config'
```

Tested with a GRE tunnel, first reported by another user on the Proxmox forum
    https://forum.proxmox.com/threads/sdn-tunnel-status-problem.160608/
and reported to the Proxmox bug tracker
    https://bugzilla.proxmox.com/show_bug.cgi?id=6078