### PR TITLE
fix: preserve leases when system shutdown

### DIFF
--- a/ifupdown2/sbin/start-networking
+++ b/ifupdown2/sbin/start-networking
@@ -136,7 +136,7 @@ stop)
         systemctl list-jobs | egrep -q '(shutdown|reboot|halt|poweroff)\.target'
         [ $? -eq 0 ] && SYSRESET=1
         if [ $SYSRESET -eq 1 ]; then
-            echo ${NAME}':' "Skipping deconfiguring the rest of the network interfaces"
+            echo ${NAME}':' "Skipping deconfiguring network interfaces"
             exit 0
         fi
 	fi

--- a/ifupdown2/sbin/start-networking
+++ b/ifupdown2/sbin/start-networking
@@ -136,8 +136,6 @@ stop)
         systemctl list-jobs | egrep -q '(shutdown|reboot|halt|poweroff)\.target'
         [ $? -eq 0 ] && SYSRESET=1
         if [ $SYSRESET -eq 1 ]; then
-            echo ${NAME}':' "Removing dhclient service files (if any)"
-            find /var/lib/dhcp/ -name "dhclient*leases" -delete
             echo ${NAME}':' "Skipping deconfiguring the rest of the network interfaces"
             exit 0
         fi


### PR DESCRIPTION
```sh
if [ $SYSRESET -eq 1 ]; then
    echo ${NAME}':' "Removing dhclient service files (if any)"
    find /var/lib/dhcp/ -name "dhclient*leases" -delete
    echo ${NAME}':' "Skipping deconfiguring the rest of the network interfaces"
    exit 0
fi
```
``ifupdown2`` currently remove all leases file when system shutdown or reboot. This will clear some information such as DUID that should not change on reboot. Remove DUID could cause system cannot obtain a reliable address via DHCPv6.  

Preserving the lease file across reboots can also speed up the DHCP process if lease not expired and address still available. ``dhclient``  send [Confirm](https://datatracker.ietf.org/doc/html/rfc8415#section-18.3.3) message to DHCP server on start if lease file already exist.

Does this ``-delete`` behavior make any sense? ifupdown does not have this behavior. I only found that this breaks my IPv6 connection. This reverts ``89df6ae``.