### PR TITLE
addons: dhcp: use ifupdown wait-for-ll6.sh method to check link-local…

### DIFF
--- a/ifupdown2/addons/dhcp.py
+++ b/ifupdown2/addons/dhcp.py
@@ -4,7 +4,6 @@
 # Author: Roopa Prabhu, roopa@cumulusnetworks.com
 #
 
-import re
 import time
 import socket
 import logging
@@ -212,10 +211,9 @@ class dhcp(Addon, moduleBase):
                     if timeout > 1:
                         time.sleep(1)
                     while timeout:
-                        addr_output = utils.exec_command('%s -6 addr show %s'
-                                                         %(utils.ip_cmd, ifaceobj.name))
-                        r = re.search('inet6 .* scope link', addr_output)
-                        if r:
+                        lladdress = utils.exec_command('%s -6 -o a s dev %s scope link -tentative'
+                                                       %(utils.ip_cmd, ifaceobj.name))
+                        if lladdress:
                             self.dhclientcmd.start6(ifaceobj.name,
                                                     wait=wait,
                                                     cmd_prefix=dhclient_cmd_prefix, duid=dhcp6_duid)


### PR DESCRIPTION
… address

When networking service was up, it match output used re.search('inet6 .* scope link', addr_output), because re.search checks for a match anywhere in the string:
	5: ens10: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
	    link/ether 52:54:00:97:3d:30 brd ff:ff:ff:ff:ff:ff
	    inet6 fe80::5054:ff:fe97:3d30/64 scope link tentative
	       valid_lft forever preferred_lft forever
It will make mistake for dhclient, because ip flag is tentative and interface can't be bound:
	error: cmd '/sbin/dhclient -6 -pf /run/dhclient6.ens10.pid -lf /var/lib/dhcp/dhclient6.ens10.leases ens10' failed: returned 1