### PR TITLE
Add tunnel-mode any support

### DIFF
--- a/ifupdown2/addons/tunnel.py
+++ b/ifupdown2/addons/tunnel.py
@@ -37,7 +37,7 @@ class tunnel(Addon, moduleBase):
         'attrs': {
             'tunnel-mode': {
                 'help': 'type of tunnel as in \'ip link\' command.',
-                'validvals': ['gre', 'gretap', 'ipip', 'sit', 'vti', 'ip6gre', 'ipip6', 'ip6ip6', 'vti6'],
+                'validvals': ['gre', 'gretap', 'ipip', 'sit', 'vti', 'ip6gre', 'ipip6', 'ip6ip6', 'vti6', 'any'],
                 'required': True,
                 'example': ['tunnel-mode gre'],
                 "aliases": ["mode"]
@@ -152,6 +152,7 @@ class tunnel(Addon, moduleBase):
             "ip6tnl": self.__get_info_data_iptun_tunnel,
             "vti": self.__get_info_data_vti_tunnel,
             "vti6": self.__get_info_data_vti_tunnel,
+            "any": self.__get_info_data_iptun_tunnel,
         }.get(link_kind, lambda x: {})(self.cache.get_link_info_data(ifname))
 
     def _up(self, ifaceobj):

--- a/ifupdown2/lib/iproute2.py
+++ b/ifupdown2/lib/iproute2.py
@@ -455,6 +455,10 @@ class IPRoute2(Cache, Requirements):
         else:
             op = "add"
 
+        # Determine the kind
+        # "any" mode creates an ip6tnl tunnel
+        kind = "ip6tnl" if mode == "any" else mode
+
         cmd = []
         if "6" in mode:
             cmd.append("-6")
@@ -471,7 +475,7 @@ class IPRoute2(Cache, Requirements):
                     cmd.append(v)
 
         utils.exec_command("%s %s" % (utils.ip_cmd, " ".join(cmd)))
-        self.__update_cache_after_link_creation(tunnelname, mode)
+        self.__update_cache_after_link_creation(tunnelname, kind)
 
     def tunnel_change(self, tunnelname, attrs=None):
         """ tunnel change function """


### PR DESCRIPTION
Can we add `mode any` as it's a legit mode according to the documentation? Everything works fine with these changes. Without this change, I get the following error `error: can't concat NoneType to bytes`

```
:~# ip link show dev test_any
Device "test_any" does not exist.
:~# ifup test_any
:~# ip -d link show dev test_any
17: test_any@NONE: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/tunnel6 2002::2 peer 2001::1 permaddr 1e34:8b9a:9e91:: promiscuity 0  allmulti 0 minmtu 68 maxmtu 65407 
    ip6tnl any remote 2001::1 local 2002::2 hoplimit 64 encaplimit 4 tclass 0x00 flowlabel 0x00000 addrgenmode eui64 numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 65536 tso_max_segs 65535 gro_max_size 65536 
```