### PR TITLE
__main__: remove PYTHONPATH injection

### DIFF
--- a/ifupdown2/__main__.py
+++ b/ifupdown2/__main__.py
@@ -26,9 +26,6 @@
 import os
 import sys
 
-sys.path.insert(0, "/root/ifupdown2/ifupdown2")
-#sys.path.append("/usr/share/ifupdown2/")
-
 try:
     from ifupdown2.lib.log import LogManager, root_logger
     from ifupdown2.lib.status import Status


### PR DESCRIPTION
this was introduced for the coverage tests which are rather underdocumented, but it seems potentially dangerous..

if extending the Python path is necessary for running the tests, it should be done only when executing the tests, e.g. via the PYTHONPATH environment variable..