### PR TITLE
gvgen: remove interpreter line

### DIFF
--- a/ifupdown2/lib/gvgen.py
+++ b/ifupdown2/lib/gvgen.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # $Id$
 """


### PR DESCRIPTION
this copy no longer has __main__ support, so doesn't need an interpreter either..