### PR TITLE
ovs addon: fix ifreload ovs_options clear

### DIFF
--- a/ifupdown2/addons/openvswitch.py
+++ b/ifupdown2/addons/openvswitch.py
@@ -155,16 +155,6 @@ class openvswitch(Addon, moduleBase):
 
         cmd_list = []
 
-        cmd = "--may-exist add-br %s"%(iface)
-        if ovsparent is not None and ovsoptions:
-            cmd = cmd + " %s" %(ovsoptions)
-
-        cmd_list.append(cmd)
-
-        if ovsparent is None and ovsoptions:
-            cmd = "set bridge %s %s" %(iface, ovsoptions)
-            cmd_list.append(cmd)
-
         #update
         if self.cache.link_exists (iface):
             # on update, delete active ports not in the new port list
@@ -190,6 +180,16 @@ class openvswitch(Addon, moduleBase):
 
             #clear old interface options
             cmd = "--if-exists clear interface %s mtu_request external-ids other_config options"%(iface)
+            cmd_list.append(cmd)
+
+        cmd = "--may-exist add-br %s"%(iface)
+        if ovsparent is not None and ovsoptions:
+            cmd = cmd + " %s" %(ovsoptions)
+
+        cmd_list.append(cmd)
+
+        if ovsparent is None and ovsoptions:
+            cmd = "set bridge %s %s" %(iface, ovsoptions)
             cmd_list.append(cmd)
 
         if ovsextra is not None:


### PR DESCRIPTION
Fixes #344.

`openvswitch.py` currently applies `ovs_options` before the bridge update path clears the existing OVS `other_config`. As a result, options configured in `/etc/network/interfaces` can be removed during `ifreload`.

This changes the update order so that stale bridge configuration is cleared first and the configured `ovs_options` are applied afterwards.

### Reproducer

Given a bridge with an option such as:

```text
ovs_options other_config:forward-bpdu=true
```

running:

```text
ifreload -a
```

should preserve the configured option.

Before this change, the option may be removed during reload. After this change, it remains configured as expected.

See #344 for the full bug report and reproduction details.
